### PR TITLE
feat: Add ticker and liquidation threshold to loan_pool initialization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,33 +18,39 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
+
       - name: Read .nvmrc
         run: echo ::set-output name=NVMRC::$(cat .nvmrc)
         id: nvm
+
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: '${{ steps.nvm.outputs.NVMRC }}'
+
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Install Stellar
-        run: |
-          cargo install --locked stellar-cli --features opt
+        run: cargo install --locked stellar-cli --features opt
+
+      - name: Build contracts
+        run: make build
+
       - name: Setup env
         run: cp .env.example .env
-      - name: Build Reflector
-        run: |
-          cd contracts/reflector
-          soroban contract build
-          cd ../..
-    
+
       - name: Install and build
         run: |
           npm install
           npm run init
+
       - name: Install, build, and upload your site output
         uses: withastro/action@v2
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,10 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+
+    - name: Read .nvmrc
+      run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+      id: nvm
+
+    - name: Setup node
+      uses: actions/setup-node@v3
       with:
-        node-version: 22.6.0
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run lint:check
-    - run: npm run format:check
+        node-version: '${{ steps.nvm.outputs.NVMRC }}'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Biome lint check
+      run: npm run lint:check
+
+    - name: Prettier format check
+      run: npm run format:check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,26 +21,11 @@ jobs:
           profile: minimal
           toolchain: stable
 
-      - name: Build Reflector
-        run: |
-          cd contracts/reflector
-          cargo build --release --target wasm32-unknown-unknown
-          cd ../..
-
-      - name: Build mock Reflector
-        run: |
-          cd contracts/reflector_mock
-          cargo build --release --target wasm32-unknown-unknown
-          cd ../..
-
-      - name: Build Loan pool contract
-        run: |
-          cd contracts/loan_pool
-          cargo build --release --target wasm32-unknown-unknown
-          cd ../..
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build
-        run: cargo build --release --target wasm32-unknown-unknown
+        run: make build
 
       - name: Run tests
         run: cargo test --verbose

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build:
+	cargo build --release --target wasm32-unknown-unknown -p reflector-oracle-mock
+	cargo build --release --target wasm32-unknown-unknown -p reflector-oracle
+	cargo build --release --target wasm32-unknown-unknown -p loan_pool
+	cargo build --release --target wasm32-unknown-unknown -p loan_manager
+	cargo build --release --target wasm32-unknown-unknown -p factory

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -219,11 +219,19 @@ mod tests {
         let loan_asset = StellarAssetClient::new(&e, &loan_token_contract_id);
         let loan_token = TokenClient::new(&e, &loan_token_contract_id);
         loan_asset.mint(&admin, &1000);
+        let loan_currency = loan_pool::Currency {
+            token_address: loan_token_contract_id.clone(),
+            ticker: Symbol::new(&e, "XLM"),
+        };
 
         let admin2 = Address::generate(&e);
         let collateral_token_contract_id = e.register_stellar_asset_contract(admin2.clone());
         let collateral_asset = StellarAssetClient::new(&e, &collateral_token_contract_id);
         let collateral_token = TokenClient::new(&e, &collateral_token_contract_id);
+        let collateral_currency = loan_pool::Currency {
+            token_address: collateral_token_contract_id.clone(),
+            ticker: Symbol::new(&e, "USDC"),
+        };
 
         // Register mock Reflector contract.
         let reflector_addr = Address::from_string(&String::from_str(&e, REFLECTOR_ADDRESS));
@@ -249,10 +257,10 @@ mod tests {
 
         // ACT
         // Initialize the loan pool and deposit some of the admin's funds.
-        loan_pool_client.initialize(&loan_token_contract_id);
+        loan_pool_client.initialize(&loan_currency, &800_000);
         loan_pool_client.deposit(&admin, &1000);
 
-        collateral_pool_client.initialize(&collateral_token_contract_id);
+        collateral_pool_client.initialize(&collateral_currency, &800_000);
 
         // Create a loan.
         contract_client.initialize(&user, &10, &loan_pool_id, &100, &collateral_pool_id);

--- a/contracts/loan_pool/src/pool.rs
+++ b/contracts/loan_pool/src/pool.rs
@@ -1,16 +1,28 @@
 use crate::storage_types::PoolDataKey;
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{contracttype, Address, Env, Symbol};
 
-pub fn write_token(e: &Env, token: Address) {
-    let key: PoolDataKey = PoolDataKey::Token;
-
-    e.storage().persistent().set(&key, &token);
+#[contracttype]
+pub struct Currency {
+    pub token_address: Address,
+    pub ticker: Symbol,
 }
 
-pub fn read_token(e: &Env) -> Address {
-    let key: PoolDataKey = PoolDataKey::Token;
+pub fn write_currency(e: &Env, currency: Currency) {
+    let key = PoolDataKey::Currency;
+
+    e.storage().persistent().set(&key, &currency);
+}
+
+pub fn read_currency(e: &Env) -> Currency {
+    let key = PoolDataKey::Currency;
 
     e.storage().persistent().get(&key).unwrap()
+}
+
+pub fn write_liquidation_threshold(e: &Env, threshold: i128) {
+    let key = PoolDataKey::LiquidationThreshold;
+
+    e.storage().persistent().set(&key, &threshold);
 }
 
 pub fn write_total_shares(e: &Env, amount: i128) {

--- a/contracts/loan_pool/src/storage_types.rs
+++ b/contracts/loan_pool/src/storage_types.rs
@@ -32,8 +32,10 @@ pub struct Positions {
 #[derive(Clone)]
 #[contracttype]
 pub enum PoolDataKey {
-    // Pools tokens address
-    Token,
+    // Pool's token's address & ticker
+    Currency,
+    // The threshold when a loan should liquidate, unit is one-millionth
+    LiquidationThreshold,
     // Users positions in the pool
     Positions(Address),
     // Total amount of shares in circulation

--- a/initialize.js
+++ b/initialize.js
@@ -46,9 +46,7 @@ function fundAll() {
 function buildAll() {
   exe(`rm -f ${dirname}/target/wasm32-unknown-unknown/release/*.wasm`);
   exe(`rm -f ${dirname}/target/wasm32-unknown-unknown/release/*.d`);
-  exe(`${soroban} contract build --package loan_pool`);
-  exe(`${soroban} contract build --package reflector-oracle`);
-  exe(`${soroban} contract build`);
+  exe(`make build`);
 }
 
 function filenameNoExtension(filename) {
@@ -67,7 +65,7 @@ function deployFactory() {
 
   // try to deploy only factory contract that will be used to generate others. Maybe later it has to be some sort of admin contract?
   deploy(`${dirname}/target/wasm32-unknown-unknown/release/factory.wasm`);
-  // Deploy loans contract as there will only be one for all
+  // Deploy loan_manager contract as there will only be one for all
   deploy(`${dirname}/target/wasm32-unknown-unknown/release/loan_manager.wasm`);
 
   // const wasmFiles = readdirSync(`${dirname}/target/wasm32-unknown-unknown/release`).filter(file => file.endsWith('.wasm'));
@@ -99,23 +97,37 @@ function installAll() {
 }
 
 function deployLpWithFactory() {
-  // Deploy liquidity pool with factory contract
+  // Deploy liquidity pools with the factory contract
 
   // Read values of parameters
   const contractId = execSync(`cat ${dirname}/.soroban/contract-ids/factory.txt`).toString().trim();
   const wasmHash = execSync(`cat ${dirname}/.soroban/contract-wasm-hash/loan_pool.txt`).toString().trim();
-  const xlmTokenAddress = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
-  const usdcTokenAddress = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
-  // Generate salt
-  const salt1 = crypto.randomBytes(32).toString('hex');
-  const salt2 = crypto.randomBytes(32).toString('hex');
 
-  exe(
-    `${soroban} contract invoke --id ${contractId} --source-account alice --network testnet -- deploy --wasm_hash ${wasmHash} --salt ${salt1} --init_fn initialize --token_contract ${xlmTokenAddress}  | tr -d '"' > ${dirname}/.soroban/contract-ids/loan_pool.txt`,
-  );
-  exe(
-    `${soroban} contract invoke --id ${contractId} --source-account alice --network testnet -- deploy --wasm_hash ${wasmHash} --salt ${salt2} --init_fn initialize --token_contract ${usdcTokenAddress}  | tr -d '"' > ${dirname}/.soroban/contract-ids/usdc_pool.txt`,
-  );
+  const initializePool = (tokenAddress, ticker, salt) => {
+    exe(
+      `${soroban} contract invoke \
+--id ${contractId} \
+--source-account alice \
+--network testnet \
+-- deploy \
+--wasm_hash ${wasmHash} \
+--salt ${salt} \
+--token_address ${tokenAddress} \
+--ticker ${ticker} \
+--liquidation_threshold 800000 \
+| tr -d '"' > ${dirname}/.soroban/contract-ids/loan_pool.txt`,
+    );
+  };
+
+  // XLM Pool
+  const xlmTokenAddress = 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC';
+  const salt1 = crypto.randomBytes(32).toString('hex');
+  initializePool(xlmTokenAddress, 'XLM', salt1);
+
+  // USDC Pool
+  const usdcTokenAddress = 'CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA';
+  const salt2 = crypto.randomBytes(32).toString('hex');
+  initializePool(usdcTokenAddress, 'USDC', salt2);
 }
 
 function bind(contract) {


### PR DESCRIPTION
* Adds ticker & liquidation threshold to loan_pool initialization parameters
  * These are stored in storage, but nothing is done with them for now
* Build tweaks
  * Makefile for forcing the build order. Use `make build` to build contracts from now on.
  * CI uses the Makefile too, and Rust artifacts are now cached 🚀 