### PR TITLE
refactor: Use result instead of simulation for contract calls.

### DIFF
--- a/src/pages/_borrow/BorrowableAssetCard.tsx
+++ b/src/pages/_borrow/BorrowableAssetCard.tsx
@@ -2,8 +2,6 @@ import { Button } from '@components/Button';
 import { Card } from '@components/Card';
 import { Loading } from '@components/Loading';
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
-import type { xdr } from '@stellar/stellar-base';
-import { Api as RpcApi } from '@stellar/stellar-sdk/rpc';
 import { useCallback, useEffect, useState } from 'react';
 import { BINDING_USDC, BINDING_XLM, type CurrencyBinding } from 'src/currency-bindings';
 import { useWallet } from 'src/stellar-wallet';
@@ -34,19 +32,8 @@ export const BorrowableAssetCard = ({ currency }: BorrowableAssetCardProps) => {
     if (!contractClient) return;
 
     try {
-      const { simulation } = await contractClient.get_available_balance();
-
-      if (!simulation || !RpcApi.isSimulationSuccess(simulation)) {
-        throw 'get_contract_balance simulation was unsuccessful.';
-      }
-
-      // TODO: why do we need to cast here? The type should infer properly.
-      const value = simulation.result?.retval.value() as xdr.Int128Parts;
-      const supplied = (value.hi().toBigInt() << BigInt(64)) + value.lo().toBigInt();
-      setTotalSupplied(supplied);
-
-      // const apy = await loanPoolContract.getSupplyAPY();
-      // setSupplyAPY(formatAPY(apy));
+      const { result } = await contractClient.get_available_balance();
+      setTotalSupplied(result);
     } catch (error) {
       console.error('Error fetching contract data:', error);
     }
@@ -72,17 +59,8 @@ export const BorrowableAssetCard = ({ currency }: BorrowableAssetCardProps) => {
     if (!loanManagerClient) return;
 
     try {
-      const { simulation } = await loanManagerClient.get_price({ token: currency.ticker });
-
-      if (!simulation || !RpcApi.isSimulationSuccess(simulation)) {
-        throw 'get_price simulation was unsuccessful.';
-      }
-
-      // TODO: why do we need to cast here? The type should infer properly.
-      const value = simulation.result?.retval.value() as xdr.Int128Parts;
-      const price = (value.hi().toBigInt() << BigInt(64)) + value.lo().toBigInt();
-
-      setTotalSuppliedPrice(price);
+      const { result } = await loanManagerClient.get_price({ token: currency.ticker });
+      setTotalSuppliedPrice(result);
     } catch (error) {
       console.error('Error fetchin price data:', error);
     }

--- a/src/pages/_lend/LendableAssetCard.tsx
+++ b/src/pages/_lend/LendableAssetCard.tsx
@@ -1,13 +1,11 @@
 import { Button } from '@components/Button';
 import { Card } from '@components/Card';
 import { Loading } from '@components/Loading';
-import type { xdr } from '@stellar/stellar-base';
-import { Api as RpcApi } from '@stellar/stellar-sdk/rpc';
 import { isNil } from 'ramda';
 import { useCallback, useEffect, useState } from 'react';
 import type { CurrencyBinding } from 'src/currency-bindings';
 import { formatAmount, toDollarsFormatted } from 'src/lib/formatting';
-import { type Balance, parsei128, useWallet } from 'src/stellar-wallet';
+import { type Balance, useWallet } from 'src/stellar-wallet';
 import { DepositModal } from './DepositModal';
 
 export interface LendableAssetCardProps {
@@ -32,18 +30,8 @@ export const LendableAssetCard = ({ currency }: LendableAssetCardProps) => {
     if (!contractClient) return;
 
     try {
-      const { simulation } = await contractClient.get_contract_balance();
-
-      if (!simulation || !RpcApi.isSimulationSuccess(simulation)) {
-        throw 'get_contract_balance simulation was unsuccessful.';
-      }
-
-      // TODO: why do we need to cast here? The type should infer properly.
-      const value = simulation.result?.retval.value() as xdr.Int128Parts;
-      setTotalSupplied(parsei128(value));
-
-      // const apy = await loanPoolContract.getSupplyAPY();
-      // setSupplyAPY(formatAPY(apy));
+      const { result } = await contractClient.get_contract_balance();
+      setTotalSupplied(result);
     } catch (error) {
       console.error('Error fetching contract data:', error);
     }

--- a/src/pages/_welcome/WelcomePage.tsx
+++ b/src/pages/_welcome/WelcomePage.tsx
@@ -33,6 +33,7 @@ interface InfoCardProps {
   title: string;
   content: string;
   to: string;
+
   buttonText: string;
 }
 

--- a/src/stellar-wallet.tsx
+++ b/src/stellar-wallet.tsx
@@ -1,11 +1,8 @@
 import { FREIGHTER_ID, StellarWalletsKit, WalletNetwork, allowAllModules } from '@creit.tech/stellar-wallets-kit';
-import type { xdr } from '@stellar/stellar-base';
 import * as StellarSdk from '@stellar/stellar-sdk';
-import { Api as RpcApi } from '@stellar/stellar-sdk/rpc';
 import { type PropsWithChildren, createContext, useContext, useEffect, useState } from 'react';
 
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
-import type { contractClient } from '@contracts/pool_xlm';
 import type { SupportedCurrency } from 'currencies';
 import { CURRENCY_BINDINGS } from './currency-bindings';
 
@@ -78,28 +75,14 @@ const createWalletObj = (address: string): Wallet => ({
   displayName: `${address.slice(0, 4)}...${address.slice(-4)}`,
 });
 
-const fetchAllPositions = async (address: string): Promise<PositionsRecord> => {
+const fetchAllPositions = async (user: string): Promise<PositionsRecord> => {
   const positionsArr = await Promise.all(
     CURRENCY_BINDINGS.map(async ({ contractClient, ticker }) => [
       ticker,
-      await fetchPositions(address, contractClient),
+      (await contractClient.get_user_balance({ user })).result,
     ]),
   );
   return Object.fromEntries(positionsArr);
-};
-
-const fetchPositions = async (user: string, poolClient: typeof contractClient): Promise<Positions> => {
-  const { simulation } = await poolClient.get_user_balance({ user });
-
-  if (!simulation || !RpcApi.isSimulationSuccess(simulation)) {
-    throw 'get_user_balance simulation was unsuccessful.';
-  }
-
-  const result = simulation.result?.retval.value() as xdr.ScMapEntry[];
-  const collateral = parsei128(result[0]?.val().value() as xdr.Int128Parts);
-  const liabilities = parsei128(result[1]?.val().value() as xdr.Int128Parts);
-  const receivables = parsei128(result[2]?.val().value() as xdr.Int128Parts);
-  return { receivables, liabilities, collateral };
 };
 
 const createBalanceRecord = (balances: Balance[]): BalanceRecord =>
@@ -112,29 +95,21 @@ const createBalanceRecord = (balances: Balance[]): BalanceRecord =>
     return acc;
   }, {} as BalanceRecord);
 
-export const parsei128 = (raw: xdr.Int128Parts): bigint => (raw.hi().toBigInt() << BigInt(64)) + raw.lo().toBigInt();
-
 const fetchAllPrices = async (): Promise<PriceRecord> => {
-  const XLM = await fetchPriceData('XLM');
-  const wBTC = await fetchPriceData('BTC');
-  const wETH = await fetchPriceData('ETH');
-  const USDC = await fetchPriceData('USDC');
-  const EURC = await fetchPriceData('EURC');
+  const [XLM, wBTC, wETH, USDC, EURC] = await Promise.all([
+    fetchPriceData('XLM'),
+    fetchPriceData('BTC'),
+    fetchPriceData('ETH'),
+    fetchPriceData('USDC'),
+    fetchPriceData('EURC'),
+  ]);
   return { XLM, wBTC, wETH, USDC, EURC };
 };
 
 const fetchPriceData = async (token: string): Promise<bigint> => {
   try {
-    const { simulation } = await loanManagerClient.get_price({ token });
-
-    if (!simulation || !RpcApi.isSimulationSuccess(simulation)) {
-      throw 'get_price simulation was unsuccessful.';
-    }
-
-    // TODO: why do we need to cast here? The type should infer properly.
-    const value = simulation.result?.retval.value() as xdr.Int128Parts;
-
-    return parsei128(value);
+    const { result } = await loanManagerClient.get_price({ token });
+    return result;
   } catch (error) {
     console.error('Error fetching price data:', error);
     return 0n;


### PR DESCRIPTION
Huomasin, että näissä contract kutsuissa on result-arvo jossa on suoraan toi oikein tyypitetty data. Onko joku syy miksei voisi tehdä näin?