### PR TITLE
feat: loan liquidations

### DIFF
--- a/.github/workflows/verify-build.yml
+++ b/.github/workflows/verify-build.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build contracts
         run: make build
 
+      - name: Run tests
+        run: cargo test --release
+
       - name: Run clippy
         run: cargo clippy -- -D warnings
 

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -456,9 +456,9 @@ impl LoanManager {
         e.storage().persistent().set(&key, &new_loan);
 
         (
-            borrowed_amount - amount,
+            new_borrowed_amount,
             collateral_amount - collateral_amount_bonus,
-            collateral_amount_bonus,
+            new_collateral_amount,
         )
     }
 }

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -417,8 +417,8 @@ impl LoanManager {
             &owner,
         );
 
-        let borrowed_ticker = Symbol::new(&e, "XLM");
-        let collateral_ticker = Symbol::new(&e, "USDC");
+        let borrowed_ticker = borrow_pool_client.get_currency().ticker;
+        let collateral_ticker = collateral_pool_client.get_currency().ticker;
         let new_borrowed_amount = borrowed_amount - amount;
         let new_collateral_amount = collateral_amount - collateral_amount_bonus;
 
@@ -996,6 +996,7 @@ mod tests {
     fn liquidate() {
         // ARRANGE
         let e = Env::default();
+        e.budget().reset_unlimited();
         e.mock_all_auths_allowing_non_root_auth();
         e.ledger().with_mut(|li| {
             li.sequence_number = 100_000;
@@ -1088,5 +1089,7 @@ mod tests {
         assert_eq!(user_loan.borrowed_amount, 5_003);
         assert_eq!(user_loan.health_factor, 10_999_400);
         assert_eq!(user_loan.collateral_amount, 5_503);
+
+        e.budget().print();
     }
 }

--- a/contracts/loan_manager/src/contract.rs
+++ b/contracts/loan_manager/src/contract.rs
@@ -144,6 +144,7 @@ impl LoanManager {
 
         // FIXME: Currently one can call initialize multiple times to change same addresses loan
         let loan = Loan {
+            owner: user.clone(),
             borrowed_amount,
             borrowed_from,
             collateral_amount,
@@ -312,6 +313,7 @@ impl LoanManager {
         user.require_auth();
 
         let Loan {
+            owner,
             borrowed_amount,
             borrowed_from,
             collateral_amount,
@@ -356,6 +358,7 @@ impl LoanManager {
             };
         } else {
             let loan = Loan {
+                owner,
                 borrowed_amount: new_borrowed_amount,
                 borrowed_from,
                 collateral_amount,

--- a/contracts/loan_manager/src/storage_types.rs
+++ b/contracts/loan_manager/src/storage_types.rs
@@ -11,7 +11,7 @@ pub(crate) const POSITIONS_LIFETIME_THRESHOLD: u32 = POSITIONS_BUMP_AMOUNT - DAY
 #[derive(Clone)]
 #[contracttype]
 pub struct Loan {
-    pub owner: Address,
+    pub borrower: Address,
     pub borrowed_amount: i128,
     pub borrowed_from: Address,
     pub collateral_amount: i128,

--- a/contracts/loan_manager/src/storage_types.rs
+++ b/contracts/loan_manager/src/storage_types.rs
@@ -11,6 +11,7 @@ pub(crate) const POSITIONS_LIFETIME_THRESHOLD: u32 = POSITIONS_BUMP_AMOUNT - DAY
 #[derive(Clone)]
 #[contracttype]
 pub struct Loan {
+    pub owner: Address,
     pub borrowed_amount: i128,
     pub borrowed_from: Address,
     pub collateral_amount: i128,

--- a/contracts/loan_pool/src/contract.rs
+++ b/contracts/loan_pool/src/contract.rs
@@ -72,6 +72,7 @@ impl LoanPoolContract {
             amount <= receivables,
             "Amount can not be greater than receivables!"
         );
+        assert!(amount <= Self::get_available_balance(e.clone()));
 
         // TODO: Decrease AvailableBalance
         pool::change_available_balance(&e, -amount);
@@ -395,9 +396,7 @@ mod test {
 
         assert_eq!(result, amount);
 
-        let withdraw_result: (i128, i128) = contract_client.withdraw(&user, &amount);
-
-        assert_eq!(withdraw_result, (amount, amount));
+        contract_client.withdraw(&user, &amount);
     }
 
     #[test]
@@ -466,5 +465,47 @@ mod test {
         assert_eq!(result, amount);
 
         contract_client.withdraw(&user, &(amount * 2));
+    }
+    #[test]
+    #[should_panic]
+    fn withdraw_more_than_available_balance() {
+        let e: Env = Env::default();
+        e.mock_all_auths();
+
+        let admin: Address = Address::generate(&e);
+        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
+        let stellar_asset = StellarAssetClient::new(&e, &token_contract_id);
+        let token = TokenClient::new(&e, &token_contract_id);
+        let currency = Currency {
+            token_address: token_contract_id,
+            ticker: Symbol::new(&e, "XLM"),
+        };
+
+        let user = Address::generate(&e);
+        stellar_asset.mint(&user, &1000);
+        assert_eq!(token.balance(&user), 1000);
+
+        let user2 = Address::generate(&e);
+        stellar_asset.mint(&user2, &1000);
+
+        let contract_id = e.register_contract(None, LoanPoolContract);
+        let contract_client = LoanPoolContractClient::new(&e, &contract_id);
+        let amount: i128 = 100;
+
+        contract_client.initialize(
+            &Address::generate(&e),
+            &currency,
+            &TEST_LIQUIDATION_THRESHOLD,
+        );
+
+        let result: i128 = contract_client.deposit(&user, &amount);
+
+        assert_eq!(result, amount);
+
+        contract_client.borrow(&user2, &500);
+
+        let withdraw_result: (i128, i128) = contract_client.withdraw(&user, &amount);
+
+        assert_eq!(withdraw_result, (amount, amount));
     }
 }

--- a/contracts/loan_pool/src/contract.rs
+++ b/contracts/loan_pool/src/contract.rs
@@ -209,6 +209,48 @@ impl LoanPoolContract {
         pool::change_available_balance(&e, amount);
         pool::change_total_balance(&e, amount);
     }
+
+    pub fn liquidate(
+        e: Env,
+        user: Address,
+        amount: i128,
+        unpaid_interest: i128,
+        loan_owner: Address,
+    ) {
+        let loan_manager_addr = pool::read_loan_manager_addr(&e);
+        loan_manager_addr.require_auth();
+
+        let amount_to_admin = if amount < unpaid_interest {
+            amount / 10
+        } else {
+            unpaid_interest / 10
+        };
+
+        let amount_to_pool = amount - amount_to_admin;
+
+        let client = token::Client::new(&e, &pool::read_currency(&e).token_address);
+        client.transfer(&user, &e.current_contract_address(), &amount_to_pool);
+        client.transfer(&user, &loan_manager_addr, &amount_to_admin);
+
+        positions::decrease_positions(&e, loan_owner, 0, amount, 0);
+        pool::change_available_balance(&e, amount);
+        pool::change_total_balance(&e, amount);
+    }
+
+    pub fn liquidate_transfer_collateral(
+        e: Env,
+        user: Address,
+        amount_collateral: i128,
+        loan_owner: Address,
+    ) {
+        let loan_manager_addr = pool::read_loan_manager_addr(&e);
+        loan_manager_addr.require_auth();
+
+        let client = token::Client::new(&e, &pool::read_currency(&e).token_address);
+        client.transfer(&e.current_contract_address(), &user, &amount_collateral);
+
+        positions::decrease_positions(&e, loan_owner, 0, 0, amount_collateral);
+    }
 }
 
 #[cfg(test)]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11022,6 +11022,8 @@
     },
     "packages/loan_manager/node_modules/@stellar/stellar-sdk": {
       "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.1.0.tgz",
+      "integrity": "sha512-Va0hu9SaPezmMbO5eMwL5D15Wrx1AGWRtxayUDRWV2Fr3ynY58mvCZS1vsgNQ4kE8MZe3nBVKv6T9Kzqwgx1PQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@stellar/stellar-base": "^12.0.1",
@@ -11035,6 +11037,8 @@
     },
     "packages/loan_manager/node_modules/typescript": {
       "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
- Added owner to Loans
- Renamed owner -> borrower
- Added liquidation functionality
- Added constant liquidation bonus/penalty of 5% in USD value
- Liquidations also handle unpaid interest and team share from it

As a temporary fix I disabled loan creation in case user already has an active loan. Until now it would've just overwritten the existing loan.