### PR TITLE
feat: Borrow & deposit modal 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "android-tzdata"
@@ -43,23 +43,23 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -82,9 +82,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -103,9 +103,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes-lit"
@@ -121,11 +127,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -136,15 +142,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -155,15 +161,15 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
 ]
@@ -203,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d2b3721e861707777e3195b0158f950ae6dc4a27e4d02ff9f67e3eb3de199e"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
  "syn",
@@ -213,16 +219,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.1"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -241,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -251,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
@@ -265,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -276,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -319,15 +324,15 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest",
@@ -363,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -415,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.5"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fnv"
@@ -438,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -451,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "group"
@@ -474,9 +479,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hex"
@@ -504,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -544,12 +549,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -570,24 +575,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -597,18 +602,18 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libm"
@@ -632,41 +637,46 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.4.1"
+name = "num-conv"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -675,37 +685,36 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "p256"
@@ -721,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pkcs8"
@@ -736,12 +745,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "platforms"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,15 +752,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.15"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -774,18 +780,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -846,30 +852,30 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "sec1"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -880,24 +886,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -906,27 +912,29 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "610f75ff4a8e3cb29b85da56eabdd1bff5b06739059a4b8e2967fef32e5d9944"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.4.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.1.0",
+ "indexmap 2.6.0",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -934,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.4.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -966,10 +974,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.1.0"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
@@ -977,15 +991,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44877373b3dc6c662377cb1600e3a62706d75e484b6064f9cd22e467c676b159"
+checksum = "2f57a68ef8777e28e274de0f3a88ad9a5a41d9a2eb461b4dd800b086f0e83b80"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -995,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590add16843a61b01844e19e89bccaaee6aa21dc76809017b0662c17dc139ee9"
+checksum = "2fd1c89463835fe6da996318156d39f424b4f167c725ec692e5a7a2d4e694b3d"
 dependencies = [
  "arbitrary",
  "crate-git-revision",
@@ -1014,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-guest"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8dc43acdd6c7e7b371acf44fc1a7dac24934ae3b2f05fafd618818548176"
+checksum = "6bfb2536811045d5cd0c656a324cbe9ce4467eb734c7946b74410d90dea5d0ce"
 dependencies = [
  "soroban-env-common",
  "static_assertions",
@@ -1024,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e25aaffe0c62eb65e0e349f725b4b8b13ad0764d78a15aab5bbccb5c4797726"
+checksum = "2b7a32c28f281c423189f1298960194f0e0fc4eeb72378028171e556d8cd6160"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1057,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "21.2.0"
+version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e16b761459fdf3c4b62b24df3941498d14e5246e6fadfb4774ed8114d243aa4"
+checksum = "242926fe5e0d922f12d3796cd7cd02dd824e5ef1caa088f45fce20b618309f64"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1072,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.5.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46f8b134b1e0b517f70d24dd72399cd263fd18c3c7cfcb5e56ffc6de9dad0c3"
+checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
 dependencies = [
  "serde",
  "serde_json",
@@ -1086,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.5.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40db0cacbd6e87c97a320fd8d24e636ef488b5aacde8a6a918e10fedc4382662"
+checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
@@ -1106,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.5.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f24c6b0c46e41852a8603bb32d43cf6a4046ce65483f6383903ec653118cd90"
+checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1126,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.5.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4b1f3745bba12bf060ff9ad2174e5d7e7a32b0b82b0ff90129a285763a093f"
+checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1138,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.5.1"
+version = "21.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d60f09c937307d96d28c0ecd49ed40a025fca8319f44eb17318abbc2229d4ec5"
+checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1216,21 +1230,21 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1239,18 +1253,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.55"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3de26b0965292219b4287ff031fcba86837900fe9cd2b34ea8ad893c0953d2"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.55"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268026685b2be38d7103e9e507c938a1fcb3d7e6eb15e87870b617bf37b6d581"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1259,12 +1273,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -1279,10 +1294,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -1294,15 +1310,15 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1312,19 +1328,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -1337,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1347,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1360,15 +1377,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_core"
@@ -1388,15 +1405,15 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.6.0",
  "semver",
 ]
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]
@@ -1407,125 +1424,96 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.0"
+name = "windows_i686_gnullvm"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ resolver = "2"
 members = ["contracts/*"]
 
 [workspace.dependencies]
-soroban-sdk = "21.5.1"
-soroban-token-sdk = "21.5.1"
+soroban-sdk = "21.7.4"
+soroban-token-sdk = "21.7.4"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/loan_pool/src/contract.rs
+++ b/contracts/loan_pool/src/contract.rs
@@ -165,7 +165,7 @@ impl LoanPoolContract {
     }
 
     /// Get user's positions in the pool
-    pub fn get_user_balance(e: Env, user: Address) -> Positions {
+    pub fn get_user_positions(e: Env, user: Address) -> Positions {
         positions::read_positions(&e, &user)
     }
 

--- a/currencies.ts
+++ b/currencies.ts
@@ -11,7 +11,7 @@ export type Currency = {
 // TODO: use environment variables for the addresses.
 
 export const CURRENCY_XLM: Currency = {
-  name: 'Stellar Lumen',
+  name: 'Stellar Lumens',
   ticker: 'XLM',
   tokenContractAddress: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
   loanPoolName: 'pool_xlm',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4741,10 +4741,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/factory": {
-      "resolved": "packages/factory",
-      "link": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5884,10 +5880,6 @@
     },
     "node_modules/loan_manager": {
       "resolved": "packages/loan_manager",
-      "link": true
-    },
-    "node_modules/loan_pool": {
-      "resolved": "packages/loan_pool",
       "link": true
     },
     "node_modules/locate-path": {
@@ -10083,10 +10075,6 @@
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
       "license": "MIT"
     },
-    "node_modules/usdc_pool": {
-      "resolved": "packages/usdc_pool",
-      "link": true
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
@@ -11013,37 +11001,13 @@
     },
     "packages/factory": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "12.1.0",
         "buffer": "6.0.3"
       },
       "devDependencies": {
         "typescript": "5.3.3"
-      }
-    },
-    "packages/factory/node_modules/@stellar/stellar-sdk": {
-      "version": "12.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.0.1",
-        "axios": "^1.7.2",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "packages/factory/node_modules/typescript": {
-      "version": "5.3.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/loan_manager": {
@@ -11083,37 +11047,13 @@
     },
     "packages/loan_pool": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "12.1.0",
         "buffer": "6.0.3"
       },
       "devDependencies": {
         "typescript": "5.3.3"
-      }
-    },
-    "packages/loan_pool/node_modules/@stellar/stellar-sdk": {
-      "version": "12.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.0.1",
-        "axios": "^1.7.2",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "packages/loan_pool/node_modules/typescript": {
-      "version": "5.3.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "packages/pool_eurc": {
@@ -11313,37 +11253,13 @@
     },
     "packages/usdc_pool": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "12.1.0",
         "buffer": "6.0.3"
       },
       "devDependencies": {
         "typescript": "5.3.3"
-      }
-    },
-    "packages/usdc_pool/node_modules/@stellar/stellar-sdk": {
-      "version": "12.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^12.0.1",
-        "axios": "^1.7.2",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "packages/usdc_pool/node_modules/typescript": {
-      "version": "5.3.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     }
   }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.81.0"
 targets = ["wasm32-unknown-unknown"]
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -3,36 +3,38 @@ import { Link } from 'react-router-dom';
 
 export interface ButtonProps {
   onClick?: () => void;
-  color?: ButtonColor;
+  variant?: ButtonVariant;
   disabled?: boolean;
   className?: string;
 }
 
-export type ButtonColor = 'black' | 'white' | 'ghost';
+export type ButtonVariant = 'black' | 'white' | 'ghost' | 'outline';
 
-const buttonStyle = (color: ButtonColor) => {
-  return `btn ${getButtonColor(color)} font-semibold text-base rounded-full px-8 py-2`;
+const buttonStyle = (variant: ButtonVariant) => {
+  return `btn ${getButtonVariant(variant)} font-semibold text-base rounded-full px-8 py-2`;
 };
 
-const getButtonColor = (color: ButtonColor): string => {
-  switch (color) {
+const getButtonVariant = (variant: ButtonVariant): string => {
+  switch (variant) {
     case 'black':
       return 'btn-neutral text-white';
     case 'white':
       return 'btn-primary';
     case 'ghost':
       return 'btn-ghost';
+    case 'outline':
+      return 'btn-outline';
   }
 };
 
 export const Button = ({
   onClick,
-  color = 'black',
+  variant = 'black',
   disabled = false,
   className = '',
   children,
 }: PropsWithChildren<ButtonProps>) => (
-  <button type="button" onClick={onClick} disabled={disabled} className={`${buttonStyle(color)} ${className}`}>
+  <button type="button" onClick={onClick} disabled={disabled} className={`${buttonStyle(variant)} ${className}`}>
     {children}
   </button>
 );

--- a/src/components/CryptoAmountSelector.tsx
+++ b/src/components/CryptoAmountSelector.tsx
@@ -1,4 +1,4 @@
-import { SCALAR_7, toDollarsFormatted } from '@lib/formatting';
+import { formatCentAmount } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import type { ChangeEvent } from 'react';
 import { Button } from './Button';
@@ -6,8 +6,8 @@ import { Button } from './Button';
 export interface CryptoAmountSelectorProps {
   max: string;
   value: string;
+  valueCents: bigint | undefined;
   ticker: SupportedCurrency;
-  price: bigint | undefined;
   onChange: (ev: ChangeEvent<HTMLInputElement>) => void;
   onSelectMaximum: () => void;
 }
@@ -15,13 +15,11 @@ export interface CryptoAmountSelectorProps {
 export const CryptoAmountSelector = ({
   max,
   value,
+  valueCents,
   ticker,
-  price,
   onChange,
   onSelectMaximum,
 }: CryptoAmountSelectorProps) => {
-  const dollarValue = price ? toDollarsFormatted(price, BigInt(value) * SCALAR_7) : undefined;
-
   return (
     <>
       <input type="range" min={0} max={max} value={value ?? '0'} className="range" onChange={onChange} />
@@ -37,7 +35,7 @@ export const CryptoAmountSelector = ({
           <input type="number" value={value} onChange={onChange} placeholder="" className="text-right w-2/3" />
           <span className="text-grey w-1/3">{ticker}</span>
         </label>
-        <span className="w-1/3">{dollarValue && `≈ ${dollarValue}`}</span>
+        <span className="w-1/3">{valueCents ? `≈ ${formatCentAmount(valueCents)}` : null}</span>
         <Button variant="outline" onClick={onSelectMaximum}>
           Select maximum
         </Button>

--- a/src/components/CryptoAmountSelector.tsx
+++ b/src/components/CryptoAmountSelector.tsx
@@ -1,8 +1,8 @@
+import { isBalanceZero } from '@lib/converters';
 import { formatCentAmount } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
-import { isNil, useWith } from 'ramda';
+import { isNil } from 'ramda';
 import type { ChangeEvent } from 'react';
-import { CURRENCY_BINDINGS_ARR } from 'src/currency-bindings';
 import { useWallet } from 'src/stellar-wallet';
 import { Button } from './Button';
 
@@ -13,7 +13,12 @@ export interface CryptoAmountSelectorProps {
   ticker: SupportedCurrency;
   onChange: (ev: ChangeEvent<HTMLInputElement>) => void;
   onSelectMaximum: () => void;
-  onSelectTicker?: (ticker: SupportedCurrency) => void;
+  tickerChangeOptions?: TickerChangeOptions;
+}
+
+export interface TickerChangeOptions {
+  options: SupportedCurrency[];
+  onSelectTicker: (ticker: SupportedCurrency) => void;
 }
 
 export const CryptoAmountSelector = ({
@@ -23,7 +28,7 @@ export const CryptoAmountSelector = ({
   ticker,
   onChange,
   onSelectMaximum,
-  onSelectTicker,
+  tickerChangeOptions,
 }: CryptoAmountSelectorProps) => (
   <>
     <input type="range" min={0} max={max} value={value ?? '0'} className="range" onChange={onChange} />
@@ -35,7 +40,7 @@ export const CryptoAmountSelector = ({
       <span>|</span>
     </div>
     <div className="flex flex-row items-center max-w-full gap-2">
-      {isNil(onSelectTicker) ? (
+      {isNil(tickerChangeOptions) ? (
         <label className="input input-bordered flex items-center gap-2 w-1/2">
           <input type="number" value={value} onChange={onChange} placeholder="" className="text-right w-1/2" />
           <span className="text-grey w-1/2">{ticker}</span>
@@ -53,10 +58,10 @@ export const CryptoAmountSelector = ({
             className="select select-bordered w-1/2 join-item"
             value={ticker}
             onChange={(ev) => {
-              onSelectTicker(ev.target.value as SupportedCurrency);
+              tickerChangeOptions.onSelectTicker(ev.target.value as SupportedCurrency);
             }}
           >
-            {CURRENCY_BINDINGS_ARR.map(({ ticker }) => (
+            {tickerChangeOptions.options.map((ticker) => (
               <TickerOption key={ticker} ticker={ticker} />
             ))}
           </select>
@@ -73,7 +78,7 @@ export const CryptoAmountSelector = ({
 const TickerOption = ({ ticker }: { ticker: SupportedCurrency }) => {
   const { walletBalances } = useWallet();
   const balance = walletBalances[ticker];
-  const disabled = isNil(balance) || balance.balance === '0';
+  const disabled = isNil(balance) || isBalanceZero(balance.balance);
 
   return (
     <option disabled={disabled} value={ticker}>

--- a/src/components/CryptoAmountSelector.tsx
+++ b/src/components/CryptoAmountSelector.tsx
@@ -1,6 +1,9 @@
 import { formatCentAmount } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
+import { isNil, useWith } from 'ramda';
 import type { ChangeEvent } from 'react';
+import { CURRENCY_BINDINGS_ARR } from 'src/currency-bindings';
+import { useWallet } from 'src/stellar-wallet';
 import { Button } from './Button';
 
 export interface CryptoAmountSelectorProps {
@@ -10,6 +13,7 @@ export interface CryptoAmountSelectorProps {
   ticker: SupportedCurrency;
   onChange: (ev: ChangeEvent<HTMLInputElement>) => void;
   onSelectMaximum: () => void;
+  onSelectTicker?: (ticker: SupportedCurrency) => void;
 }
 
 export const CryptoAmountSelector = ({
@@ -19,27 +23,61 @@ export const CryptoAmountSelector = ({
   ticker,
   onChange,
   onSelectMaximum,
-}: CryptoAmountSelectorProps) => {
-  return (
-    <>
-      <input type="range" min={0} max={max} value={value ?? '0'} className="range" onChange={onChange} />
-      <div className="flex w-full justify-between px-2 text-xs">
-        <span>|</span>
-        <span>|</span>
-        <span>|</span>
-        <span>|</span>
-        <span>|</span>
-      </div>
-      <div className="flex flex-row items-center max-w-full gap-2">
-        <label className="input input-bordered flex items-center gap-2 w-1/3">
-          <input type="number" value={value} onChange={onChange} placeholder="" className="text-right w-2/3" />
-          <span className="text-grey w-1/3">{ticker}</span>
+  onSelectTicker,
+}: CryptoAmountSelectorProps) => (
+  <>
+    <input type="range" min={0} max={max} value={value ?? '0'} className="range" onChange={onChange} />
+    <div className="flex w-full justify-between px-2 text-xs">
+      <span>|</span>
+      <span>|</span>
+      <span>|</span>
+      <span>|</span>
+      <span>|</span>
+    </div>
+    <div className="flex flex-row items-center max-w-full gap-2">
+      {isNil(onSelectTicker) ? (
+        <label className="input input-bordered flex items-center gap-2 w-1/2">
+          <input type="number" value={value} onChange={onChange} placeholder="" className="text-right w-1/2" />
+          <span className="text-grey w-1/2">{ticker}</span>
         </label>
-        <span className="w-1/3">{valueCents ? `≈ ${formatCentAmount(valueCents)}` : null}</span>
-        <Button variant="outline" onClick={onSelectMaximum}>
-          Select maximum
-        </Button>
-      </div>
-    </>
+      ) : (
+        <div className="join w-1/2">
+          <input
+            type="number"
+            value={value}
+            onChange={onChange}
+            placeholder=""
+            className="input input-bordered text-right w-1/2 join-item"
+          />
+          <select
+            className="select select-bordered w-1/2 join-item"
+            value={ticker}
+            onChange={(ev) => {
+              onSelectTicker(ev.target.value as SupportedCurrency);
+            }}
+          >
+            {CURRENCY_BINDINGS_ARR.map(({ ticker }) => (
+              <TickerOption key={ticker} ticker={ticker} />
+            ))}
+          </select>
+        </div>
+      )}
+      <span className="w-1/3">{valueCents ? `≈ ${formatCentAmount(valueCents)}` : null}</span>
+      <Button variant="outline" onClick={onSelectMaximum}>
+        Select maximum
+      </Button>
+    </div>
+  </>
+);
+
+const TickerOption = ({ ticker }: { ticker: SupportedCurrency }) => {
+  const { walletBalances } = useWallet();
+  const balance = walletBalances[ticker];
+  const disabled = isNil(balance) || balance.balance === '0';
+
+  return (
+    <option disabled={disabled} value={ticker}>
+      {ticker}
+    </option>
   );
 };

--- a/src/components/CryptoAmountSelector.tsx
+++ b/src/components/CryptoAmountSelector.tsx
@@ -1,0 +1,47 @@
+import { SCALAR_7, toDollarsFormatted } from '@lib/formatting';
+import type { SupportedCurrency } from 'currencies';
+import type { ChangeEvent } from 'react';
+import { Button } from './Button';
+
+export interface CryptoAmountSelectorProps {
+  max: string;
+  value: string;
+  ticker: SupportedCurrency;
+  price: bigint | undefined;
+  onChange: (ev: ChangeEvent<HTMLInputElement>) => void;
+  onSelectMaximum: () => void;
+}
+
+export const CryptoAmountSelector = ({
+  max,
+  value,
+  ticker,
+  price,
+  onChange,
+  onSelectMaximum,
+}: CryptoAmountSelectorProps) => {
+  const dollarValue = price ? toDollarsFormatted(price, BigInt(value) * SCALAR_7) : undefined;
+
+  return (
+    <>
+      <input type="range" min={0} max={max} value={value ?? '0'} className="range" onChange={onChange} />
+      <div className="flex w-full justify-between px-2 text-xs">
+        <span>|</span>
+        <span>|</span>
+        <span>|</span>
+        <span>|</span>
+        <span>|</span>
+      </div>
+      <div className="flex flex-row items-center max-w-full gap-2">
+        <label className="input input-bordered flex items-center gap-2 w-1/3">
+          <input type="number" value={value} onChange={onChange} placeholder="" className="text-right w-2/3" />
+          <span className="text-grey w-1/3">{ticker}</span>
+        </label>
+        <span className="w-1/3">{dollarValue && `≈ ${dollarValue}`}</span>
+        <Button variant="outline" onClick={onSelectMaximum}>
+          Select maximum
+        </Button>
+      </div>
+    </>
+  );
+};

--- a/src/components/WalletCard/AssetsModal.tsx
+++ b/src/components/WalletCard/AssetsModal.tsx
@@ -4,7 +4,7 @@ import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { isNil } from 'ramda';
 import { useState } from 'react';
-import { CURRENCY_BINDINGS, type CurrencyBinding } from 'src/currency-bindings';
+import { CURRENCY_BINDINGS } from 'src/currency-bindings';
 import { useWallet } from 'src/stellar-wallet';
 
 export interface AssetsModalProps {
@@ -60,7 +60,7 @@ const TableRow = ({ receivables, ticker }: TableRowProps) => {
 
   if (receivables === 0n) return null;
 
-  const { icon, name, contractClient } = CURRENCY_BINDINGS.find((b) => b.ticker === ticker) as CurrencyBinding;
+  const { icon, name, contractClient } = CURRENCY_BINDINGS[ticker];
   const price = prices?.[ticker];
 
   const handleWithdrawClick = async () => {

--- a/src/components/WalletCard/AssetsModal.tsx
+++ b/src/components/WalletCard/AssetsModal.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { isNil } from 'ramda';
 import { useState } from 'react';
 import { CURRENCY_BINDINGS, type CurrencyBinding } from 'src/currency-bindings';
-import { formatAmount, toDollarsFormatted } from 'src/lib/formatting';
 import { useWallet } from 'src/stellar-wallet';
 
 export interface AssetsModalProps {
@@ -35,7 +35,7 @@ const AssetsModal = ({ modalId, onClose }: AssetsModalProps) => {
           </tbody>
         </table>
         <div className="modal-action">
-          <Button color="ghost" className="ml-auto" onClick={onClose}>
+          <Button variant="ghost" className="ml-auto" onClick={onClose}>
             Close
           </Button>
         </div>

--- a/src/components/WalletCard/LoansModal.tsx
+++ b/src/components/WalletCard/LoansModal.tsx
@@ -6,7 +6,7 @@ import { Loading } from '@components/Loading';
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
-import { CURRENCY_BINDINGS, type CurrencyBinding } from 'src/currency-bindings';
+import { CURRENCY_BINDINGS } from 'src/currency-bindings';
 import { useWallet } from 'src/stellar-wallet';
 
 export interface AssetsModalProps {
@@ -62,7 +62,7 @@ const TableRow = ({ liabilities, ticker }: TableRowProps) => {
 
   if (liabilities === 0n) return null;
 
-  const { icon, name } = CURRENCY_BINDINGS.find((b) => b.ticker === ticker) as CurrencyBinding;
+  const { icon, name } = CURRENCY_BINDINGS[ticker];
   const price = prices?.[ticker];
 
   const handleWithdrawClick = async () => {

--- a/src/components/WalletCard/LoansModal.tsx
+++ b/src/components/WalletCard/LoansModal.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
+import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { CURRENCY_BINDINGS, type CurrencyBinding } from 'src/currency-bindings';
-import { formatAmount, toDollarsFormatted } from 'src/lib/formatting';
 import { useWallet } from 'src/stellar-wallet';
 
 export interface AssetsModalProps {
@@ -37,7 +37,7 @@ const LoansModal = ({ modalId, onClose }: AssetsModalProps) => {
           </tbody>
         </table>
         <div className="modal-action">
-          <Button color="ghost" className="ml-auto" onClick={onClose}>
+          <Button variant="ghost" className="ml-auto" onClick={onClose}>
             Close
           </Button>
         </div>

--- a/src/components/WalletCard/WalletCard.tsx
+++ b/src/components/WalletCard/WalletCard.tsx
@@ -1,7 +1,7 @@
 import { Loading } from '@components/Loading';
+import { formatCentAmount, toCents } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { isNil } from 'ramda';
-import { formatCentAmount, toCents } from 'src/lib/formatting';
 import { type PositionsRecord, type PriceRecord, useWallet } from 'src/stellar-wallet';
 import { Button } from '../Button';
 import { Card } from '../Card';
@@ -92,7 +92,7 @@ const WalletCard = () => {
                 <p className="text-grey">Total deposited</p>
                 <p className="text-xl leading-5">{formatCentAmount(values.receivablesCents)}</p>
               </div>
-              <Button color="white" className="w-44" onClick={openAssetModal}>
+              <Button variant="white" className="w-44" onClick={openAssetModal}>
                 View Assets
               </Button>
             </div>
@@ -105,7 +105,7 @@ const WalletCard = () => {
                 <p className="text-grey">Total borrowed</p>
                 <p className="text-xl leading-5">{formatCentAmount(values.liabilitiesCents)}</p>
               </div>
-              <Button color="white" className="w-44" onClick={openLoansModal}>
+              <Button variant="white" className="w-44" onClick={openLoansModal}>
                 View Loans
               </Button>
             </div>

--- a/src/components/WalletCard/WalletCard.tsx
+++ b/src/components/WalletCard/WalletCard.tsx
@@ -1,7 +1,7 @@
 import { Loading } from '@components/Loading';
 import type { SupportedCurrency } from 'currencies';
 import { isNil } from 'ramda';
-import { formatDollarAmount, toDollars } from 'src/lib/formatting';
+import { formatCentAmount, toCents } from 'src/lib/formatting';
 import { type PositionsRecord, type PriceRecord, useWallet } from 'src/stellar-wallet';
 import { Button } from '../Button';
 import { Card } from '../Card';
@@ -48,8 +48,8 @@ const WalletCard = () => {
     );
   }
 
-  const hasReceivables = values.receivablesDollars > 0n;
-  const hasLiabilities = values.liabilitiesDollars > 0n;
+  const hasReceivables = values.receivablesCents > 0n;
+  const hasLiabilities = values.liabilitiesCents > 0n;
 
   const openAssetModal = () => {
     const modalEl = document.getElementById(ASSET_MODAL_ID) as HTMLDialogElement;
@@ -90,7 +90,7 @@ const WalletCard = () => {
             <div className="flex flex-row">
               <div className="w-40 mr-10">
                 <p className="text-grey">Total deposited</p>
-                <p className="text-xl leading-5">{formatDollarAmount(values.receivablesDollars)}</p>
+                <p className="text-xl leading-5">{formatCentAmount(values.receivablesCents)}</p>
               </div>
               <Button color="white" className="w-44" onClick={openAssetModal}>
                 View Assets
@@ -103,7 +103,7 @@ const WalletCard = () => {
             <div className="flex flex-row">
               <div className="w-40 mr-10">
                 <p className="text-grey">Total borrowed</p>
-                <p className="text-xl leading-5">{formatDollarAmount(values.liabilitiesDollars)}</p>
+                <p className="text-xl leading-5">{formatCentAmount(values.liabilitiesCents)}</p>
               </div>
               <Button color="white" className="w-44" onClick={openLoansModal}>
                 View Loans
@@ -121,21 +121,21 @@ const WalletCard = () => {
 };
 
 type ValueObj = {
-  receivablesDollars: bigint;
-  liabilitiesDollars: bigint;
+  receivablesCents: bigint;
+  liabilitiesCents: bigint;
 };
 
 const calculateTotalValue = (prices: PriceRecord, positions: PositionsRecord): ValueObj => {
   return Object.entries(positions).reduce(
     (acc, [ticker, { receivables, liabilities }]) => {
       const price = prices[ticker as SupportedCurrency];
-      acc.receivablesDollars += toDollars(price, receivables);
-      acc.liabilitiesDollars += toDollars(price, liabilities);
+      acc.receivablesCents += toCents(price, receivables);
+      acc.liabilitiesCents += toCents(price, liabilities);
       return acc;
     },
     {
-      receivablesDollars: 0n,
-      liabilitiesDollars: 0n,
+      receivablesCents: 0n,
+      liabilitiesCents: 0n,
     } as ValueObj,
   );
 };

--- a/src/currency-bindings.ts
+++ b/src/currency-bindings.ts
@@ -51,4 +51,12 @@ export const BINDING_EURC: CurrencyBinding = {
   icon: EURCIcon.src,
 };
 
-export const CURRENCY_BINDINGS = [BINDING_XLM, BINDING_WBTC, BINDING_WETH, BINDING_USDC, BINDING_EURC];
+export const CURRENCY_BINDINGS = {
+  XLM: BINDING_XLM,
+  wBTC: BINDING_WBTC,
+  wETH: BINDING_WETH,
+  USDC: BINDING_USDC,
+  EURC: BINDING_EURC,
+} as const;
+
+export const CURRENCY_BINDINGS_ARR = Object.values(CURRENCY_BINDINGS);

--- a/src/lib/converters.ts
+++ b/src/lib/converters.ts
@@ -1,2 +1,4 @@
 // Stellar operates with a precision of 7 decimal places for assets like XLM & USDC.
 export const to7decimals = (amount: string): bigint => BigInt(amount) * BigInt(10_000_000);
+
+export const getIntegerPart = (decimal: string): string => Number.parseInt(decimal).toString();

--- a/src/lib/converters.ts
+++ b/src/lib/converters.ts
@@ -2,3 +2,5 @@
 export const to7decimals = (amount: string): bigint => BigInt(amount) * BigInt(10_000_000);
 
 export const getIntegerPart = (decimal: string): string => Number.parseInt(decimal).toString();
+
+export const isBalanceZero = (decimal: string): boolean => Number.parseInt(decimal.replace('.', '')) === 0;

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,8 +1,14 @@
 // 7 decimal numbers is the smallest unit of XLM, stroop.
 const SCALAR_7 = 10_000_000n;
+const CENTS_SCALAR = SCALAR_7 * 100_000n;
 
 const TEN_K = 10_000n * SCALAR_7;
 const ONE_M = 1_000_000n * SCALAR_7;
+
+// 10 thousand dollars = 1 million cents
+const TEN_K_CENTS = 10_000n * 100n;
+// 1 million dollars = 100 million cents
+const ONE_M_CENTS = 1_000_000n * 100n;
 
 export const formatAmount = (amount: bigint): string => {
   if (amount === 0n) return '0';
@@ -18,18 +24,21 @@ export const formatAmount = (amount: bigint): string => {
 
 export const toDollarsFormatted = (price: bigint, amount: bigint) => {
   if (amount === 0n) return '$0';
-  return formatDollarAmount(toDollars(price, amount));
+  return formatCentAmount(toCents(price, amount));
 };
 
-export const toDollars = (price: bigint, amount: bigint) => ((price / SCALAR_7) * amount) / SCALAR_7;
+export const toCents = (price: bigint, amount: bigint) => {
+  return (price * amount) / CENTS_SCALAR;
+};
 
-export const formatDollarAmount = (amount: bigint) => {
-  if (amount === 0n) return '$0';
-  if (amount > ONE_M) {
-    return `$${(Number(amount) / (1_000_000 * 10_000_000)).toFixed(2)}M`;
+export const formatCentAmount = (cents: bigint) => {
+  if (cents === 0n) return '$0';
+
+  if (cents > ONE_M_CENTS) {
+    return `$${(Number(cents) / 100_000_000).toFixed(2)} M`;
   }
-  if (amount > TEN_K) {
-    return `$${(Number(amount) / (1_000 * 10_000_000)).toFixed(1)}K`;
+  if (cents > TEN_K_CENTS) {
+    return `$${(Number(cents) / 100_000).toFixed(2)} K`;
   }
-  return `$${(Number(amount) / 10_000_000).toFixed(1)}`;
+  return `$${(Number(cents) / 100).toFixed(1)} `;
 };

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -31,6 +31,10 @@ export const toCents = (price: bigint, amount: bigint): bigint => {
   return (price * amount) / CENTS_SCALAR;
 };
 
+export const fromCents = (price: bigint, cents: bigint): bigint => {
+  return (cents * CENTS_SCALAR) / price;
+}
+
 export const formatCentAmount = (cents: bigint): string => {
   if (cents === 0n) return '$0';
 

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,6 +1,6 @@
 // 7 decimal numbers is the smallest unit of XLM, stroop.
-const SCALAR_7 = 10_000_000n;
-const CENTS_SCALAR = SCALAR_7 * 100_000n;
+export const SCALAR_7 = 10_000_000n;
+export const CENTS_SCALAR = SCALAR_7 * SCALAR_7 * 100_000n;
 
 const TEN_K = 10_000n * SCALAR_7;
 const ONE_M = 1_000_000n * SCALAR_7;
@@ -22,16 +22,16 @@ export const formatAmount = (amount: bigint): string => {
   return `${(Number(amount) / 10_000_000).toFixed(1)}`;
 };
 
-export const toDollarsFormatted = (price: bigint, amount: bigint) => {
+export const toDollarsFormatted = (price: bigint, amount: bigint): string => {
   if (amount === 0n) return '$0';
   return formatCentAmount(toCents(price, amount));
 };
 
-export const toCents = (price: bigint, amount: bigint) => {
+export const toCents = (price: bigint, amount: bigint): bigint => {
   return (price * amount) / CENTS_SCALAR;
 };
 
-export const formatCentAmount = (cents: bigint) => {
+export const formatCentAmount = (cents: bigint): string => {
   if (cents === 0n) return '$0';
 
   if (cents > ONE_M_CENTS) {

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -33,7 +33,7 @@ export const toCents = (price: bigint, amount: bigint): bigint => {
 
 export const fromCents = (price: bigint, cents: bigint): bigint => {
   return (cents * CENTS_SCALAR) / price;
-}
+};
 
 export const formatCentAmount = (cents: bigint): string => {
   if (cents === 0n) return '$0';

--- a/src/pages/_borrow/BorrowModal.tsx
+++ b/src/pages/_borrow/BorrowModal.tsx
@@ -6,7 +6,7 @@ import { getIntegerPart, to7decimals } from '@lib/converters';
 import { SCALAR_7, fromCents, toCents } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { type ChangeEvent, useState } from 'react';
-import { CURRENCY_BINDINGS, type CurrencyBinding } from 'src/currency-bindings';
+import { CURRENCY_BINDINGS, CURRENCY_BINDINGS_ARR, type CurrencyBinding } from 'src/currency-bindings';
 import { useWallet } from 'src/stellar-wallet';
 
 const HEALTH_FACTOR_MIN_THRESHOLD = 1.2;
@@ -30,6 +30,10 @@ export const BorrowModal = ({ modalId, onClose, currency, totalSupplied }: Borro
   const [loanAmount, setLoanAmount] = useState<string>('0');
   const [collateralTicker, setCollateralTicker] = useState<SupportedCurrency>('XLM');
   const [collateralAmount, setCollateralAmount] = useState<string>('0');
+
+  const collateralOptions: SupportedCurrency[] = CURRENCY_BINDINGS_ARR.filter((c) => c.ticker !== ticker).map(
+    ({ ticker }) => ticker,
+  );
 
   const collateralBalance = walletBalances[collateralTicker];
 
@@ -133,7 +137,7 @@ export const BorrowModal = ({ modalId, onClose, currency, totalSupplied }: Borro
         <h3 className="font-bold text-xl mb-4">Borrow {name}</h3>
         <p className="my-4">
           Borrow {name} using another asset as a collateral. The value of the collateral must exceed the value of the
-          borrowed asset.
+          borrowed asset. You will receive the collateral back to your wallet after repaying the loan in full.
         </p>
         <p className="my-4">
           The higher the value of the collateral is to the value of the borrowed asset, the safer this loan is. This is
@@ -164,7 +168,10 @@ export const BorrowModal = ({ modalId, onClose, currency, totalSupplied }: Borro
           ticker={collateralTicker}
           onChange={handleCollateralAmountChange}
           onSelectMaximum={handleSelectMaxCollateral}
-          onSelectTicker={handleCollateralTickerChange}
+          tickerChangeOptions={{
+            onSelectTicker: handleCollateralTickerChange,
+            options: collateralOptions,
+          }}
         />
 
         <p className="font-bold mt-6 mb-2">Health Factor</p>

--- a/src/pages/_borrow/BorrowPage.tsx
+++ b/src/pages/_borrow/BorrowPage.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@components/Card';
 import { Table } from '@components/Table';
 import WalletCard from '@components/WalletCard/WalletCard';
-import { CURRENCY_BINDINGS } from 'src/currency-bindings';
+import { CURRENCY_BINDINGS_ARR } from 'src/currency-bindings';
 import { BorrowableAsset } from './BorrowableAsset';
 
 const links = [
@@ -17,7 +17,7 @@ const BorrowPage = () => (
       <div className="px-12 pb-12 pt-4">
         <h1 className="text-2xl font-semibold mb-4 tracking-tight">Borrow Assets</h1>
         <Table headers={['Asset', null, 'Available Balance', 'Borrow APY', null]}>
-          {CURRENCY_BINDINGS.map((currency) => (
+          {CURRENCY_BINDINGS_ARR.map((currency) => (
             <BorrowableAsset key={currency.ticker} currency={currency} />
           ))}
         </Table>

--- a/src/pages/_lend/DepositModal.tsx
+++ b/src/pages/_lend/DepositModal.tsx
@@ -2,6 +2,7 @@ import { Button } from '@components/Button';
 import { CryptoAmountSelector } from '@components/CryptoAmountSelector';
 import { Loading } from '@components/Loading';
 import { getIntegerPart, to7decimals } from '@lib/converters';
+import { SCALAR_7, toCents } from '@lib/formatting';
 import { type ChangeEvent, useState } from 'react';
 import type { CurrencyBinding } from 'src/currency-bindings';
 import { useWallet } from 'src/stellar-wallet';
@@ -21,6 +22,8 @@ export const DepositModal = ({ modalId, onClose, currency }: DepositModalProps) 
 
   const balance = walletBalances[ticker];
   const price = prices?.[ticker];
+
+  const amountCents = price ? toCents(price, BigInt(amount) * SCALAR_7) : undefined;
 
   if (!balance) return null;
 
@@ -75,8 +78,8 @@ export const DepositModal = ({ modalId, onClose, currency }: DepositModalProps) 
         <CryptoAmountSelector
           max={max}
           value={amount}
+          valueCents={amountCents}
           ticker={ticker}
-          price={price}
           onChange={handleAmountChange}
           onSelectMaximum={handleSelectMaxLoan}
         />

--- a/src/pages/_lend/LendPage.tsx
+++ b/src/pages/_lend/LendPage.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@components/Card';
 import { Table } from '@components/Table';
 import WalletCard from '@components/WalletCard/WalletCard';
-import { CURRENCY_BINDINGS } from 'src/currency-bindings';
+import { CURRENCY_BINDINGS_ARR } from 'src/currency-bindings';
 import { LendableAsset } from './LendableAsset';
 
 const links = [
@@ -18,7 +18,7 @@ const LendPage = () => {
         <div className="px-12 pb-12 pt-4">
           <h1 className="text-2xl font-semibold mb-4 tracking-tight">Lend Assets</h1>
           <Table headers={['Asset', null, 'Total Supplied', 'Supply APY', null]}>
-            {CURRENCY_BINDINGS.map((currency) => (
+            {CURRENCY_BINDINGS_ARR.map((currency) => (
               <LendableAsset currency={currency} key={currency.ticker} />
             ))}
           </Table>

--- a/src/pages/_lend/LendableAsset.tsx
+++ b/src/pages/_lend/LendableAsset.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import { isNil } from 'ramda';
 import { useCallback, useEffect, useState } from 'react';
 import type { CurrencyBinding } from 'src/currency-bindings';
-import { formatAmount, toDollarsFormatted } from 'src/lib/formatting';
 import { type Balance, useWallet } from 'src/stellar-wallet';
 import { DepositModal } from './DepositModal';
 

--- a/src/stellar-wallet.tsx
+++ b/src/stellar-wallet.tsx
@@ -79,7 +79,7 @@ const fetchAllPositions = async (user: string): Promise<PositionsRecord> => {
   const positionsArr = await Promise.all(
     CURRENCY_BINDINGS.map(async ({ contractClient, ticker }) => [
       ticker,
-      (await contractClient.get_user_balance({ user })).result,
+      (await contractClient.get_user_positions({ user })).result,
     ]),
   );
   return Object.fromEntries(positionsArr);

--- a/src/stellar-wallet.tsx
+++ b/src/stellar-wallet.tsx
@@ -4,7 +4,7 @@ import { type PropsWithChildren, createContext, useContext, useEffect, useState 
 
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import type { SupportedCurrency } from 'currencies';
-import { CURRENCY_BINDINGS } from './currency-bindings';
+import { CURRENCY_BINDINGS_ARR } from './currency-bindings';
 
 const HorizonServer = new StellarSdk.Horizon.Server('https://horizon-testnet.stellar.org/');
 
@@ -77,7 +77,7 @@ const createWalletObj = (address: string): Wallet => ({
 
 const fetchAllPositions = async (user: string): Promise<PositionsRecord> => {
   const positionsArr = await Promise.all(
-    CURRENCY_BINDINGS.map(async ({ contractClient, ticker }) => [
+    CURRENCY_BINDINGS_ARR.map(async ({ contractClient, ticker }) => [
       ticker,
       (await contractClient.get_user_positions({ user })).result,
     ]),

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -15,6 +15,10 @@ export default {
       },
       black: '#000',
       primary: '#000',
+      red: '#e51414',
+      yellow: '#e18c02',
+      blue: '#0048ff',
+      green: '#0fdd13',
     },
     fontSize: {
       sm: ['14px', '20px'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       "@images/*": ["src/images/*"],
       "@components/*": ["src/components/*"],
       "@pages/*": ["src/pages/*"],
-      "@contracts/*": ["src/contracts/*"]
+      "@contracts/*": ["src/contracts/*"],
+      "@lib/*": ["src/lib/*"]
     }
   }
 }


### PR DESCRIPTION
* Better USD calculations, cent values as bigint now used.
* New deposit modal
  * Uses an updated crypto selector component with live USD value shown
* New borrow modal
  * Many things requested by our testers implemented
  * The modal now explains what the collateral is, and that you will get it back when repaying the loan
  * The modal shows the health factor live when changing the loan & collateral amounts
  * Won't allow creating a loan with insufficient collateral, this previously caused a quite non-descriptive panic from the contract
  * USD values for both loan & collateral amount shown, the selector component is shared by both borrow & deposit
  * Allow changing the collateral ticker
* Borrow button is disabled if the user has no collateral balance on some other token
<img width="956" alt="Screenshot 2024-10-17 at 21 03 00" src="https://github.com/user-attachments/assets/9f6cd96c-3416-4678-bf09-5969e962ff95">
<img width="941" alt="Screenshot 2024-10-17 at 21 03 18" src="https://github.com/user-attachments/assets/43aa0cfd-5e6b-49bf-885e-fe91e9a37aef">

