### PR TITLE
chore: Update deprecated Stellar Asset contract generation in tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ledger-snapshot"
-version = "21.7.4"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956476365ff3f9bf429ff23fa11ac75798347a2bfc3c9e5e12638dbe3a6b17a8"
+checksum = "43793d5deb5fc27c3e14e036e24cb3afcf7d1e2a172d9166e37f3d174b928749"
 dependencies = [
  "serde",
  "serde_json",
@@ -1100,15 +1100,16 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk"
-version = "21.7.4"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7767472f00a4053e86d5c37b3c814a6bc01c9230004713328d73d2a3444e72e"
+checksum = "25c539fecb2862ce0c1f49880134660a855e2d35889692e01d1e8d8a1e53f98e"
 dependencies = [
  "arbitrary",
  "bytes-lit",
  "ctor",
  "ed25519-dalek",
  "rand",
+ "rustc_version",
  "serde",
  "serde_json",
  "soroban-env-guest",
@@ -1120,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-sdk-macros"
-version = "21.7.4"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8cf8fa10f3ad62509ff7b25cd696fb837da692c40264d1abb393e117aad75c"
+checksum = "a9ad528a770ec7adb524635d855b424ae2fd4fef04fb702bb0ab466a4c354d78"
 dependencies = [
  "crate-git-revision",
  "darling",
@@ -1140,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec"
-version = "21.7.4"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d306f61ef5c1247dca1562e04cc74b6e3adf107631c168b2ce0d5f1cf1fa13"
+checksum = "5b262c82d840552f71ee9254f2e928622fd803bd4df4815e65f73f73efc2fa9c"
 dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
@@ -1152,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-spec-rust"
-version = "21.7.4"
+version = "21.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed06e0f622fb878fc439643f2fd86163223ac33a468beeea96e5d33f79b08b3"
+checksum = "85a061820c2dd0bd3ece9411e0dd3aeb6ed9ca2b7d64270eda9e798c3b6dec5f"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ resolver = "2"
 members = ["contracts/*"]
 
 [workspace.dependencies]
-soroban-sdk = "21.7.4"
-soroban-token-sdk = "21.7.4"
+soroban-sdk = "21.7.6"
+soroban-token-sdk = "21.7.6"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/loan_pool/src/contract.rs
+++ b/contracts/loan_pool/src/contract.rs
@@ -267,21 +267,19 @@ mod test {
 
     #[test]
     fn initialize() {
-        let e: Env = Env::default();
+        let e = Env::default();
         e.mock_all_auths();
 
-        let admin: Address = Address::generate(&e);
-        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
-        let stellar_asset = StellarAssetClient::new(&e, &token_contract_id);
-        let token = TokenClient::new(&e, &token_contract_id);
+        let admin = Address::generate(&e);
+        let token = e.register_stellar_asset_contract_v2(admin.clone());
+        let stellar_asset = StellarAssetClient::new(&e, &token.address());
         let currency = Currency {
-            token_address: token_contract_id,
+            token_address: token.address(),
             ticker: Symbol::new(&e, "XLM"),
         };
 
         let user = Address::generate(&e);
         stellar_asset.mint(&user, &1000);
-        assert_eq!(token.balance(&user), 1000);
 
         let contract_id = e.register_contract(None, LoanPoolContract);
         let contract_client = LoanPoolContractClient::new(&e, &contract_id);
@@ -295,21 +293,19 @@ mod test {
 
     #[test]
     fn deposit() {
-        let e: Env = Env::default();
+        let e = Env::default();
         e.mock_all_auths();
 
-        let admin: Address = Address::generate(&e);
-        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
-        let stellar_asset = StellarAssetClient::new(&e, &token_contract_id);
-        let token = TokenClient::new(&e, &token_contract_id);
+        let admin = Address::generate(&e);
+        let token = e.register_stellar_asset_contract_v2(admin.clone());
+        let stellar_asset = StellarAssetClient::new(&e, &token.address());
         let currency = Currency {
-            token_address: token_contract_id,
+            token_address: token.address(),
             ticker: Symbol::new(&e, "XLM"),
         };
 
         let user = Address::generate(&e);
         stellar_asset.mint(&user, &1000);
-        assert_eq!(token.balance(&user), 1000);
 
         let contract_id = e.register_contract(None, LoanPoolContract);
         let contract_client = LoanPoolContractClient::new(&e, &contract_id);
@@ -333,12 +329,12 @@ mod test {
 
         let admin = Address::generate(&e);
 
-        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
-        let asset = StellarAssetClient::new(&e, &token_contract_id);
+        let token = e.register_stellar_asset_contract_v2(admin.clone());
+        let asset = StellarAssetClient::new(&e, &token.address());
 
-        let token_client = TokenClient::new(&e, &token_contract_id);
+        let token_client = TokenClient::new(&e, &token.address());
         let currency = Currency {
-            token_address: token_contract_id,
+            token_address: token.address(),
             ticker: Symbol::new(&e, "XLM"),
         };
 
@@ -366,21 +362,19 @@ mod test {
 
     #[test]
     fn withdraw() {
-        let e: Env = Env::default();
+        let e = Env::default();
         e.mock_all_auths();
 
-        let admin: Address = Address::generate(&e);
-        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
-        let stellar_asset = StellarAssetClient::new(&e, &token_contract_id);
-        let token = TokenClient::new(&e, &token_contract_id);
+        let admin = Address::generate(&e);
+        let token = e.register_stellar_asset_contract_v2(admin.clone());
+        let stellar_asset = StellarAssetClient::new(&e, &token.address());
         let currency = Currency {
-            token_address: token_contract_id,
+            token_address: token.address(),
             ticker: Symbol::new(&e, "XLM"),
         };
 
         let user = Address::generate(&e);
         stellar_asset.mint(&user, &1000);
-        assert_eq!(token.balance(&user), 1000);
 
         let contract_id = e.register_contract(None, LoanPoolContract);
         let contract_client = LoanPoolContractClient::new(&e, &contract_id);
@@ -402,21 +396,19 @@ mod test {
     #[test]
     #[should_panic]
     fn deposit_more_than_account_balance() {
-        let e: Env = Env::default();
+        let e = Env::default();
         e.mock_all_auths();
 
-        let admin: Address = Address::generate(&e);
-        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
-        let stellar_asset = StellarAssetClient::new(&e, &token_contract_id);
-        let token = TokenClient::new(&e, &token_contract_id);
+        let admin = Address::generate(&e);
+        let token = e.register_stellar_asset_contract_v2(admin.clone());
+        let stellar_asset = StellarAssetClient::new(&e, &token.address());
         let currency = Currency {
-            token_address: token_contract_id,
+            token_address: token.address(),
             ticker: Symbol::new(&e, "XLM"),
         };
 
         let user = Address::generate(&e);
         stellar_asset.mint(&user, &1000);
-        assert_eq!(token.balance(&user), 1000);
 
         let contract_id = e.register_contract(None, LoanPoolContract);
         let contract_client = LoanPoolContractClient::new(&e, &contract_id);
@@ -434,21 +426,19 @@ mod test {
     #[test]
     #[should_panic(expected = "Amount can not be greater than receivables!")]
     fn withdraw_more_than_balance() {
-        let e: Env = Env::default();
+        let e = Env::default();
         e.mock_all_auths();
 
-        let admin: Address = Address::generate(&e);
-        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
-        let stellar_asset = StellarAssetClient::new(&e, &token_contract_id);
-        let token = TokenClient::new(&e, &token_contract_id);
+        let admin = Address::generate(&e);
+        let token = e.register_stellar_asset_contract_v2(admin.clone());
+        let stellar_asset = StellarAssetClient::new(&e, &token.address());
         let currency = Currency {
-            token_address: token_contract_id,
+            token_address: token.address(),
             ticker: Symbol::new(&e, "XLM"),
         };
 
         let user = Address::generate(&e);
         stellar_asset.mint(&user, &1000);
-        assert_eq!(token.balance(&user), 1000);
 
         let contract_id = e.register_contract(None, LoanPoolContract);
         let contract_client = LoanPoolContractClient::new(&e, &contract_id);
@@ -469,21 +459,19 @@ mod test {
     #[test]
     #[should_panic]
     fn withdraw_more_than_available_balance() {
-        let e: Env = Env::default();
+        let e = Env::default();
         e.mock_all_auths();
 
-        let admin: Address = Address::generate(&e);
-        let token_contract_id = e.register_stellar_asset_contract(admin.clone());
-        let stellar_asset = StellarAssetClient::new(&e, &token_contract_id);
-        let token = TokenClient::new(&e, &token_contract_id);
+        let admin = Address::generate(&e);
+        let token = e.register_stellar_asset_contract_v2(admin.clone());
+        let stellar_asset = StellarAssetClient::new(&e, &token.address());
         let currency = Currency {
-            token_address: token_contract_id,
+            token_address: token.address(),
             ticker: Symbol::new(&e, "XLM"),
         };
 
         let user = Address::generate(&e);
         stellar_asset.mint(&user, &1000);
-        assert_eq!(token.balance(&user), 1000);
 
         let user2 = Address::generate(&e);
         stellar_asset.mint(&user2, &1000);


### PR DESCRIPTION
Bumped Stellar SDK version by a couple patch versions to the latest.

`Env.register_stellar_asset_contract` was printing warnings of being deprecated. Updated all of those to the recommended `Env.register_stellar_asset_contract_v2`.

Also removed some asserts I don't think we needed, which tested whether minting assets via Stellar SDK actually worked. I don't think we need to assert Stellar SDK works as it should. 😄 