### PR TITLE
refactor: Move pool interactions into a React Context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Footer from '@components/Footer';
 import Nav from '@components/Nav';
+import { PoolProvider } from '@contexts/pool-context';
 import { WalletProvider } from '@contexts/wallet-context';
 import BorrowPage from '@pages/_borrow/BorrowPage';
 import LandingPage from '@pages/_landing/LandingPage';
@@ -39,7 +40,9 @@ const App = () => {
   return (
     <React.StrictMode>
       <WalletProvider>
-        <RouterProvider router={router} />
+        <PoolProvider>
+          <RouterProvider router={router} />
+        </PoolProvider>
       </WalletProvider>
     </React.StrictMode>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,12 @@ import { Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Footer from '@components/Footer';
 import Nav from '@components/Nav';
+import { WalletProvider } from '@contexts/wallet-context';
 import BorrowPage from '@pages/_borrow/BorrowPage';
 import LandingPage from '@pages/_landing/LandingPage';
 import LendPage from '@pages/_lend/LendPage';
 import LiquidatePage from '@pages/_liquidate/LiquidatePage';
 import WelcomePage from '@pages/_welcome/WelcomePage';
-import { WalletProvider } from './stellar-wallet';
 
 const PageWrapper = () => {
   return (

--- a/src/components/CryptoAmountSelector.tsx
+++ b/src/components/CryptoAmountSelector.tsx
@@ -1,9 +1,9 @@
+import { useWallet } from '@contexts/wallet-context';
 import { isBalanceZero } from '@lib/converters';
 import { formatCentAmount } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { isNil } from 'ramda';
 import type { ChangeEvent } from 'react';
-import { useWallet } from 'src/stellar-wallet';
 import { Button } from './Button';
 
 export interface CryptoAmountSelectorProps {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,6 +1,6 @@
+import { useWallet } from '@contexts/wallet-context';
 import type { PropsWithChildren } from 'react';
 import { Link } from 'react-router-dom';
-import { useWallet } from 'src/stellar-wallet';
 import logo from '/public/laina_v3_shrinked.png';
 import { Button } from './Button';
 import Identicon from './Identicon';

--- a/src/components/WalletCard/AssetsModal.tsx
+++ b/src/components/WalletCard/AssetsModal.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { useWallet } from '@contexts/wallet-context';
 import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { isNil } from 'ramda';
 import { useState } from 'react';
 import { CURRENCY_BINDINGS } from 'src/currency-bindings';
-import { useWallet } from 'src/stellar-wallet';
 
 export interface AssetsModalProps {
   modalId: string;

--- a/src/components/WalletCard/AssetsModal.tsx
+++ b/src/components/WalletCard/AssetsModal.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { usePools } from '@contexts/pool-context';
 import { useWallet } from '@contexts/wallet-context';
 import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
@@ -55,7 +56,8 @@ interface TableRowProps {
 }
 
 const TableRow = ({ receivables, ticker }: TableRowProps) => {
-  const { wallet, prices, signTransaction, refetchBalances } = useWallet();
+  const { wallet, signTransaction, refetchBalances } = useWallet();
+  const { prices } = usePools();
   const [isWithdrawing, setIsWithdrawing] = useState(false);
 
   if (receivables === 0n) return null;

--- a/src/components/WalletCard/LoansModal.tsx
+++ b/src/components/WalletCard/LoansModal.tsx
@@ -3,11 +3,11 @@ import { useState } from 'react';
 
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { useWallet } from '@contexts/wallet-context';
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import { formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { CURRENCY_BINDINGS } from 'src/currency-bindings';
-import { useWallet } from 'src/stellar-wallet';
 
 export interface AssetsModalProps {
   modalId: string;

--- a/src/components/WalletCard/LoansModal.tsx
+++ b/src/components/WalletCard/LoansModal.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { usePools } from '@contexts/pool-context';
 import { useWallet } from '@contexts/wallet-context';
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import { formatAmount, toDollarsFormatted } from '@lib/formatting';
@@ -57,7 +58,8 @@ interface TableRowProps {
 }
 
 const TableRow = ({ liabilities, ticker }: TableRowProps) => {
-  const { wallet, prices, signTransaction, refetchBalances } = useWallet();
+  const { wallet, signTransaction, refetchBalances } = useWallet();
+  const { prices } = usePools();
   const [isRepaying, setIsRepaying] = useState(false);
 
   if (liabilities === 0n) return null;

--- a/src/components/WalletCard/WalletCard.tsx
+++ b/src/components/WalletCard/WalletCard.tsx
@@ -1,8 +1,8 @@
 import { Loading } from '@components/Loading';
+import { type PositionsRecord, type PriceRecord, useWallet } from '@contexts/wallet-context';
 import { formatCentAmount, toCents } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { isNil } from 'ramda';
-import { type PositionsRecord, type PriceRecord, useWallet } from 'src/stellar-wallet';
 import { Button } from '../Button';
 import { Card } from '../Card';
 import Identicon from '../Identicon';

--- a/src/components/WalletCard/WalletCard.tsx
+++ b/src/components/WalletCard/WalletCard.tsx
@@ -1,4 +1,5 @@
 import { Loading } from '@components/Loading';
+import { usePools } from '@contexts/pool-context';
 import { type PositionsRecord, type PriceRecord, useWallet } from '@contexts/wallet-context';
 import { formatCentAmount, toCents } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
@@ -13,7 +14,8 @@ const ASSET_MODAL_ID = 'assets-modal';
 const LOANS_MODAL_ID = 'loans-modal';
 
 const WalletCard = () => {
-  const { wallet, openConnectWalletModal, positions, prices } = useWallet();
+  const { wallet, openConnectWalletModal, positions } = useWallet();
+  const { prices } = usePools();
 
   if (!wallet) {
     return (

--- a/src/contexts/pool-context.tsx
+++ b/src/contexts/pool-context.tsx
@@ -1,0 +1,97 @@
+import { type PropsWithChildren, createContext, useCallback, useContext, useEffect, useState } from 'react';
+
+import { contractClient as loanManagerClient } from '@contracts/loan_manager';
+import type { SupportedCurrency } from 'currencies';
+import { CURRENCY_BINDINGS } from 'src/currency-bindings';
+
+export type PriceRecord = {
+  [K in SupportedCurrency]: bigint;
+};
+
+export type PoolState = {
+  totalBalance: bigint;
+  availableBalance: bigint;
+  apr: bigint;
+};
+
+export type PoolRecord = {
+  [K in SupportedCurrency]: PoolState;
+};
+
+export type PoolContext = {
+  prices: PriceRecord | null;
+  pools: PoolRecord | null;
+  refetchPools: () => void;
+};
+
+const Context = createContext<PoolContext>({
+  prices: null,
+  pools: null,
+  refetchPools: () => {},
+});
+
+const fetchAllPrices = async (): Promise<PriceRecord> => {
+  const [XLM, wBTC, wETH, USDC, EURC] = await Promise.all([
+    fetchPriceData('XLM'),
+    fetchPriceData('BTC'),
+    fetchPriceData('ETH'),
+    fetchPriceData('USDC'),
+    fetchPriceData('EURC'),
+  ]);
+  return { XLM, wBTC, wETH, USDC, EURC };
+};
+
+const fetchPriceData = async (ticker: string): Promise<bigint> => {
+  try {
+    const { result } = await loanManagerClient.get_price({ token: ticker });
+    return result;
+  } catch (error) {
+    console.error(`Error fetching price data: for ${ticker}`, error);
+    return 0n;
+  }
+};
+
+const fetchPoolState = async (ticker: SupportedCurrency): Promise<PoolState> => {
+  const { contractClient } = CURRENCY_BINDINGS[ticker];
+  const { result: totalBalance } = await contractClient.get_contract_balance();
+  const { result: availableBalance } = await contractClient.get_available_balance();
+  const { result: apr } = await contractClient.get_interest();
+  return { totalBalance, availableBalance, apr };
+};
+
+const fetchPools = async (): Promise<PoolRecord> => {
+  const [XLM, wBTC, wETH, USDC, EURC] = await Promise.all([
+    fetchPoolState('XLM'),
+    fetchPoolState('wBTC'),
+    fetchPoolState('wETH'),
+    fetchPoolState('USDC'),
+    fetchPoolState('EURC'),
+  ]);
+  return { XLM, wBTC, wETH, USDC, EURC };
+};
+
+export const PoolProvider = ({ children }: PropsWithChildren) => {
+  const [prices, setPrices] = useState<PriceRecord | null>(null);
+  const [pools, setPools] = useState<PoolRecord | null>(null);
+
+  const refetchPools = useCallback(() => {
+    fetchAllPrices()
+      .then((res) => setPrices(res))
+      .catch((err) => console.error('Error fetching prices', err));
+    fetchPools()
+      .then((res) => setPools(res))
+      .catch((err) => console.error('Error fetching pools', err));
+  }, []);
+
+  useEffect(() => {
+    refetchPools();
+
+    // Set up a timer for every ledger (~6 secs) to refetch state.
+    const intervalId = setInterval(refetchPools, 6000);
+    return () => clearInterval(intervalId);
+  }, [refetchPools]);
+
+  return <Context.Provider value={{ prices, pools, refetchPools }}>{children}</Context.Provider>;
+};
+
+export const usePools = (): PoolContext => useContext(Context);

--- a/src/contexts/wallet-context.tsx
+++ b/src/contexts/wallet-context.tsx
@@ -5,7 +5,7 @@ import { type PropsWithChildren, createContext, useContext, useEffect, useState 
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import { getBalances } from '@lib/horizon';
 import { type SupportedCurrency, isSupportedCurrency } from 'currencies';
-import { CURRENCY_BINDINGS_ARR } from './currency-bindings';
+import { CURRENCY_BINDINGS_ARR } from '../currency-bindings';
 
 const WALLET_TIMEOUT_DAYS = 3;
 

--- a/src/pages/_borrow/BorrowModal/BorrowModal.tsx
+++ b/src/pages/_borrow/BorrowModal/BorrowModal.tsx
@@ -1,3 +1,4 @@
+import { usePools } from '@contexts/pool-context';
 import { useWallet } from '@contexts/wallet-context';
 import type { CurrencyBinding } from 'src/currency-bindings';
 import { BorrowStep } from './BorrowStep';
@@ -12,7 +13,8 @@ export interface BorrowModalProps {
 
 export const BorrowModal = ({ modalId, onClose, currency, totalSupplied }: BorrowModalProps) => {
   const { name, ticker } = currency;
-  const { wallet, walletBalances, signTransaction, refetchBalances, prices } = useWallet();
+  const { wallet, walletBalances, signTransaction, refetchBalances } = useWallet();
+  const { prices } = usePools();
 
   const closeModal = () => {
     refetchBalances();

--- a/src/pages/_borrow/BorrowModal/BorrowModal.tsx
+++ b/src/pages/_borrow/BorrowModal/BorrowModal.tsx
@@ -1,4 +1,3 @@
-import { usePools } from '@contexts/pool-context';
 import { useWallet } from '@contexts/wallet-context';
 import type { CurrencyBinding } from 'src/currency-bindings';
 import { BorrowStep } from './BorrowStep';
@@ -8,45 +7,27 @@ export interface BorrowModalProps {
   modalId: string;
   onClose: () => void;
   currency: CurrencyBinding;
-  totalSupplied: bigint;
 }
 
-export const BorrowModal = ({ modalId, onClose, currency, totalSupplied }: BorrowModalProps) => {
+export const BorrowModal = ({ modalId, onClose, currency }: BorrowModalProps) => {
   const { name, ticker } = currency;
-  const { wallet, walletBalances, signTransaction, refetchBalances } = useWallet();
-  const { prices } = usePools();
+  const { walletBalances, refetchBalances } = useWallet();
 
   const closeModal = () => {
     refetchBalances();
     onClose();
   };
 
-  // Modal is impossible to open before the wallet is loaded.
-  if (!wallet || !walletBalances || !prices) return null;
-
-  const isTrustline = walletBalances[ticker].trustLine;
+  const isTrustline = walletBalances?.[ticker].trustLine;
 
   return (
     <dialog id={modalId} className="modal">
       <div className="modal-box w-full max-w-full md:w-[700px] p-10">
         <h3 className="font-bold text-xl mb-4">Borrow {name}</h3>
         {!isTrustline ? (
-          <TrustLineStep
-            onClose={closeModal}
-            currency={currency}
-            wallet={wallet}
-            signTransaction={signTransaction}
-            refetchBalances={refetchBalances}
-          />
+          <TrustLineStep onClose={closeModal} currency={currency} />
         ) : (
-          <BorrowStep
-            onClose={closeModal}
-            currency={currency}
-            totalSupplied={totalSupplied}
-            wallet={wallet}
-            walletBalances={walletBalances}
-            prices={prices}
-          />
+          <BorrowStep onClose={closeModal} currency={currency} />
         )}
       </div>
       {/* Invisible backdrop that closes the modal on click */}

--- a/src/pages/_borrow/BorrowModal/BorrowModal.tsx
+++ b/src/pages/_borrow/BorrowModal/BorrowModal.tsx
@@ -1,5 +1,5 @@
+import { useWallet } from '@contexts/wallet-context';
 import type { CurrencyBinding } from 'src/currency-bindings';
-import { useWallet } from 'src/stellar-wallet';
 import { BorrowStep } from './BorrowStep';
 import { TrustLineStep } from './TrustlineStep';
 

--- a/src/pages/_borrow/BorrowModal/BorrowStep.tsx
+++ b/src/pages/_borrow/BorrowModal/BorrowStep.tsx
@@ -1,13 +1,13 @@
 import { Button } from '@components/Button';
 import { CryptoAmountSelector } from '@components/CryptoAmountSelector';
 import { Loading } from '@components/Loading';
+import { type BalanceRecord, type PriceRecord, type Wallet, useWallet } from '@contexts/wallet-context';
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import { getIntegerPart, to7decimals } from '@lib/converters';
 import { SCALAR_7, fromCents, toCents } from '@lib/formatting';
 import type { SupportedCurrency } from 'currencies';
 import { type ChangeEvent, useState } from 'react';
 import { CURRENCY_BINDINGS, CURRENCY_BINDINGS_ARR, type CurrencyBinding } from 'src/currency-bindings';
-import { type BalanceRecord, type PriceRecord, type Wallet, useWallet } from 'src/stellar-wallet';
 
 const HEALTH_FACTOR_AUTO_THRESHOLD = 1.65;
 const HEALTH_FACTOR_MIN_THRESHOLD = 1.2;

--- a/src/pages/_borrow/BorrowModal/TrustlineStep.tsx
+++ b/src/pages/_borrow/BorrowModal/TrustlineStep.tsx
@@ -1,9 +1,10 @@
+import { useState } from 'react';
+
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import type { SignTransaction, Wallet } from '@contexts/wallet-context';
 import { createAddTrustlineTransaction, sendTransaction } from '@lib/horizon';
-import { useState } from 'react';
 import type { CurrencyBinding } from 'src/currency-bindings';
-import type { SignTransaction, Wallet } from 'src/stellar-wallet';
 
 export interface TrustLineStepProps {
   onClose: () => void;

--- a/src/pages/_borrow/BorrowModal/TrustlineStep.tsx
+++ b/src/pages/_borrow/BorrowModal/TrustlineStep.tsx
@@ -2,22 +2,23 @@ import { useState } from 'react';
 
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
-import type { SignTransaction, Wallet } from '@contexts/wallet-context';
+import { useWallet } from '@contexts/wallet-context';
 import { createAddTrustlineTransaction, sendTransaction } from '@lib/horizon';
 import type { CurrencyBinding } from 'src/currency-bindings';
 
 export interface TrustLineStepProps {
   onClose: () => void;
   currency: CurrencyBinding;
-  wallet: Wallet;
-  signTransaction: SignTransaction;
-  refetchBalances: () => void;
 }
 
-export const TrustLineStep = ({ onClose, currency, wallet, signTransaction, refetchBalances }: TrustLineStepProps) => {
+export const TrustLineStep = ({ onClose, currency }: TrustLineStepProps) => {
   const { name, ticker } = currency;
+  const { wallet, signTransaction, refetchBalances } = useWallet();
 
   const [isCreating, setIsCreating] = useState(false);
+
+  // Modal is impossible to open without a wallet connection.
+  if (!wallet) return null;
 
   const handleAddTrustlineClick = async () => {
     try {

--- a/src/pages/_borrow/BorrowableAsset.tsx
+++ b/src/pages/_borrow/BorrowableAsset.tsx
@@ -3,11 +3,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { useWallet } from '@contexts/wallet-context';
 import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import { isBalanceZero } from '@lib/converters';
 import { formatAPR } from '@lib/formatting';
 import type { CurrencyBinding } from 'src/currency-bindings';
-import { useWallet } from 'src/stellar-wallet';
 import { BorrowModal } from './BorrowModal/BorrowModal';
 
 interface BorrowableAssetCardProps {

--- a/src/pages/_borrow/BorrowableAsset.tsx
+++ b/src/pages/_borrow/BorrowableAsset.tsx
@@ -84,9 +84,7 @@ export const BorrowableAsset = ({ currency }: BorrowableAssetCardProps) => {
           <Button onClick={openModal}>Borrow</Button>
         )}
       </td>
-      {!isNil(pool) && (
-        <BorrowModal modalId={modalId} onClose={closeModal} currency={currency} totalSupplied={pool.availableBalance} />
-      )}
+      {!isNil(pool) && <BorrowModal modalId={modalId} onClose={closeModal} currency={currency} />}
     </tr>
   );
 };

--- a/src/pages/_borrow/BorrowableAsset.tsx
+++ b/src/pages/_borrow/BorrowableAsset.tsx
@@ -1,12 +1,12 @@
 import { isNil } from 'ramda';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { usePools } from '@contexts/pool-context';
 import { useWallet } from '@contexts/wallet-context';
-import { contractClient as loanManagerClient } from '@contracts/loan_manager';
 import { isBalanceZero } from '@lib/converters';
-import { formatAPR } from '@lib/formatting';
+import { formatAPR, formatAmount, toDollarsFormatted } from '@lib/formatting';
 import type { CurrencyBinding } from 'src/currency-bindings';
 import { BorrowModal } from './BorrowModal/BorrowModal';
 
@@ -15,15 +15,14 @@ interface BorrowableAssetCardProps {
 }
 
 export const BorrowableAsset = ({ currency }: BorrowableAssetCardProps) => {
-  const { icon, name, ticker, contractClient } = currency;
+  const { icon, name, ticker } = currency;
 
   const modalId = `borrow-modal-${ticker}`;
 
   const { wallet, walletBalances } = useWallet();
-
-  const [poolAPR, setPoolAPR] = useState<bigint | null>(null);
-  const [totalSupplied, setTotalSupplied] = useState<bigint | null>(null);
-  const [totalSuppliedPrice, setTotalSuppliedPrice] = useState<bigint | null>(null);
+  const { prices, pools } = usePools();
+  const price = prices?.[ticker];
+  const pool = pools?.[ticker];
 
   // Does the user have some other token in their wallet to use as a collateral?
   const isCollateral = !walletBalances
@@ -32,92 +31,7 @@ export const BorrowableAsset = ({ currency }: BorrowableAssetCardProps) => {
         .filter(([t, _b]) => t !== ticker)
         .some(([_t, b]) => b.trustLine && !isBalanceZero(b.balanceLine.balance));
 
-  const borrowDisabled = !wallet || !isCollateral || !totalSupplied;
-
-  const formatPoolAPR = useCallback((apr: bigint | null) => {
-    if (apr === null) return <Loading size="xs" />;
-    return formatAPR(apr);
-  }, []);
-
-  const fetchAvailableContractBalance = useCallback(async () => {
-    if (!contractClient) return;
-
-    try {
-      const { result } = await contractClient.get_available_balance();
-      setTotalSupplied(result);
-    } catch (error) {
-      console.error('Error fetching contract data:', error);
-    }
-  }, [contractClient]); // Dependency on loanPoolContract
-
-  const fetchPoolAPR = useCallback(async () => {
-    if (!contractClient) return;
-
-    try {
-      const { result } = await contractClient.get_interest();
-      setPoolAPR(result);
-    } catch (error) {
-      console.error('Error fetching APR data', error);
-    }
-  }, [contractClient]);
-
-  const formatSuppliedAmount = useCallback((amount: bigint | null) => {
-    if (amount === BigInt(0)) return '0';
-    if (!amount) return <Loading size="xs" />;
-
-    const ten_k = BigInt(10_000 * 10_000_000);
-    const one_m = BigInt(1_000_000 * 10_000_000);
-    switch (true) {
-      case amount > one_m:
-        return `${(Number(amount) / (1_000_000 * 10_000_000)).toFixed(2)}M`;
-      case amount > ten_k:
-        return `${(Number(amount) / (1_000 * 10_000_000)).toFixed(1)}K`;
-      default:
-        return `${(Number(amount) / 10_000_000).toFixed(1)}`;
-    }
-  }, []);
-
-  const fetchPriceData = useCallback(async () => {
-    if (!loanManagerClient) return;
-
-    try {
-      const { result } = await loanManagerClient.get_price({ token: currency.ticker });
-      setTotalSuppliedPrice(result);
-    } catch (error) {
-      console.error('Error fetching price data:', error);
-    }
-  }, [currency.ticker]);
-
-  const formatSuppliedAmountPrice = useCallback(
-    (price: bigint | null) => {
-      if (totalSupplied === BigInt(0)) return '$0';
-      if (!totalSupplied || !price) return null;
-
-      const ten_k = BigInt(10_000 * 10_000_000);
-      const one_m = BigInt(1_000_000 * 10_000_000);
-      const total_price = ((price / BigInt(10_000_000)) * totalSupplied) / BigInt(10_000_000);
-      switch (true) {
-        case total_price > one_m:
-          return `$${(Number(total_price) / (1_000_000 * 10_000_000)).toFixed(2)}M`;
-        case total_price > ten_k:
-          return `$${(Number(total_price) / (1_000 * 10_000_000)).toFixed(1)}K`;
-        default:
-          return `$${(Number(total_price) / 10_000_000).toFixed(1)}`;
-      }
-    },
-    [totalSupplied],
-  );
-
-  useEffect(() => {
-    // Fetch contract data immediately and set an interval to run every 6 seconds
-    fetchAvailableContractBalance();
-    fetchPriceData();
-    fetchPoolAPR();
-    const intervalId = setInterval(fetchAvailableContractBalance, 6000);
-
-    // Cleanup function to clear the interval on component unmount
-    return () => clearInterval(intervalId);
-  }, [fetchAvailableContractBalance, fetchPriceData, fetchPoolAPR]); // Now dependent on the memoized function
+  const borrowDisabled = !wallet || !isCollateral || !pool || pool.availableBalance === 0n;
 
   const openModal = () => {
     const modalEl = document.getElementById(modalId) as HTMLDialogElement;
@@ -130,11 +44,12 @@ export const BorrowableAsset = ({ currency }: BorrowableAssetCardProps) => {
   };
 
   const tooltip = useMemo(() => {
-    if (!totalSupplied) return 'The pool has no assets to borrow';
+    if (!pool) return 'The pool is loading';
+    if (pool.availableBalance === 0n) return 'the pool has no assets to borrow';
     if (!wallet) return 'Connect a wallet first';
     if (!isCollateral) return 'Another token needed for the collateral';
     return 'Something odd happened.';
-  }, [totalSupplied, wallet, isCollateral]);
+  }, [pool, wallet, isCollateral]);
 
   return (
     <tr className="border-none text-base h-[6.5rem]">
@@ -148,12 +63,14 @@ export const BorrowableAsset = ({ currency }: BorrowableAssetCardProps) => {
       </td>
 
       <td>
-        <p className="text-xl font-semibold leading-6">{formatSuppliedAmount(totalSupplied)}</p>
-        <p>{formatSuppliedAmountPrice(totalSuppliedPrice)}</p>
+        <p className="text-xl font-semibold leading-6">
+          {pool ? formatAmount(pool.availableBalance) : <Loading size="xs" />}
+        </p>
+        <p>{pool && price ? toDollarsFormatted(price, pool.availableBalance) : null}</p>
       </td>
 
       <td>
-        <p className="text-xl font-semibold leading-6">{formatPoolAPR(poolAPR)}</p>
+        <p className="text-xl font-semibold leading-6">{pool ? formatAPR(pool.apr) : <Loading size="xs" />}</p>
       </td>
 
       <td>
@@ -167,8 +84,8 @@ export const BorrowableAsset = ({ currency }: BorrowableAssetCardProps) => {
           <Button onClick={openModal}>Borrow</Button>
         )}
       </td>
-      {!isNil(totalSupplied) && (
-        <BorrowModal modalId={modalId} onClose={closeModal} currency={currency} totalSupplied={totalSupplied} />
+      {!isNil(pool) && (
+        <BorrowModal modalId={modalId} onClose={closeModal} currency={currency} totalSupplied={pool.availableBalance} />
       )}
     </tr>
   );

--- a/src/pages/_lend/DepositModal.tsx
+++ b/src/pages/_lend/DepositModal.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@components/Button';
 import { CryptoAmountSelector } from '@components/CryptoAmountSelector';
 import { Loading } from '@components/Loading';
+import { useWallet } from '@contexts/wallet-context';
 import { getIntegerPart, to7decimals } from '@lib/converters';
 import { SCALAR_7, toCents } from '@lib/formatting';
 import { type ChangeEvent, useState } from 'react';
 import type { CurrencyBinding } from 'src/currency-bindings';
-import { useWallet } from 'src/stellar-wallet';
 
 export interface DepositModalProps {
   modalId: string;

--- a/src/pages/_lend/DepositModal.tsx
+++ b/src/pages/_lend/DepositModal.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@components/Button';
 import { CryptoAmountSelector } from '@components/CryptoAmountSelector';
 import { Loading } from '@components/Loading';
+import { usePools } from '@contexts/pool-context';
 import { useWallet } from '@contexts/wallet-context';
 import { getIntegerPart, to7decimals } from '@lib/converters';
 import { SCALAR_7, toCents } from '@lib/formatting';
@@ -16,7 +17,8 @@ export interface DepositModalProps {
 export const DepositModal = ({ modalId, onClose, currency }: DepositModalProps) => {
   const { contractClient, name, ticker } = currency;
 
-  const { wallet, walletBalances, prices, signTransaction, refetchBalances } = useWallet();
+  const { wallet, walletBalances, signTransaction, refetchBalances } = useWallet();
+  const { prices } = usePools();
   const [isDepositing, setIsDepositing] = useState(false);
   const [amount, setAmount] = useState('0');
 

--- a/src/pages/_lend/LendableAsset.tsx
+++ b/src/pages/_lend/LendableAsset.tsx
@@ -1,11 +1,11 @@
 import { Button } from '@components/Button';
 import { Loading } from '@components/Loading';
+import { type Balance, useWallet } from '@contexts/wallet-context';
 import { isBalanceZero } from '@lib/converters';
 import { formatAPY, formatAmount, toDollarsFormatted } from '@lib/formatting';
 import { isNil } from 'ramda';
 import { useCallback, useEffect, useState } from 'react';
 import type { CurrencyBinding } from 'src/currency-bindings';
-import { type Balance, useWallet } from 'src/stellar-wallet';
 import { DepositModal } from './DepositModal';
 
 export interface LendableAssetProps {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
       "@components/*": ["src/components/*"],
       "@pages/*": ["src/pages/*"],
       "@contracts/*": ["src/contracts/*"],
-      "@lib/*": ["src/lib/*"]
+      "@lib/*": ["src/lib/*"],
+      "@contexts/*": ["src/contexts/*"]
     }
   }
 }


### PR DESCRIPTION
* Create a new `contexts/` folder for React contexts
* Create a new `PoolContext` which holds and updates pool state (balances, aprs, prices)
* Refactor lending & borrowing to use the new abstraction stuff.
* Add APR to borrow modal